### PR TITLE
Fix 25 Recency Based Sorting for Tags 

### DIFF
--- a/frontend/src/components/annotator/pdfViewer/Adder.vue
+++ b/frontend/src/components/annotator/pdfViewer/Adder.vue
@@ -104,7 +104,7 @@ export default {
   },
   computed: {
     recencySortingOn() {
-      return this.$store.getters["settings/getValue"]("tags.recencySortingIsOn");
+      return this.$store.getters["settings/getValue"]("tags.recencySortingIsOn") === "true";
     },
     defaultTagSet() {
       return parseInt(this.$store.getters["settings/getValue"]("tags.tagSet.default"));
@@ -138,7 +138,7 @@ export default {
       }
       
       // sort tags by recency 
-      if (this.recencySortingOn === true) {
+      if (this.recencySortingOn) {
           tagList.sort((a,b) => {
           const idxA = this.usageHistory.indexOf(a.name);
           const idxB = this.usageHistory.indexOf(b.name);


### PR DESCRIPTION
Fixes #25 
The setting recencySortingIsOn() was loaded but never transformed from string to boolean making the if clauses evaluate as true when the string was "false"