### PR TITLE
BUG #48 Studies with Starting Date cannot be started

### DIFF
--- a/frontend/src/components/study/StudyModal.vue
+++ b/frontend/src/components/study/StudyModal.vue
@@ -314,9 +314,6 @@ export default {
     },
     started() {
       if (this.study && this.study.start !== null) {
-        if (!(this.study.start instanceof Date)) {
-          throw new Error("Invalid type for study start date. Expected a Date object.");
-        }
         return (new Date(this.study.start) < new Date());
       }
       return true;


### PR DESCRIPTION
fixes #48 : study.start is a string and was checked if it is a Date object one line before being cast to a Date object.
The bug was introduced to the started() and ended() computed properties in October 2024, in a PairProgramming in November 2024 the ended() function and its bug were removed entirely but the unpassable assertion in started slipped through