### PR TITLE
Improve Single-Select Table UI by Hiding Multi-Select Count (issue 184)

### DIFF
--- a/frontend/src/basic/Table.vue
+++ b/frontend/src/basic/Table.vue
@@ -274,7 +274,7 @@
     </table>
   </div>
   <div
-    v-if="selectableRows"
+    v-if="selectableRows && !(options && options.singleSelect)"
     class="text-end text-muted small mb-2"
   >
     {{ selectedCount }} of {{ totalSelectableCount }} selected


### PR DESCRIPTION
### Main Description
Adjust table selection UI to hide the “selected count” line when single-select mode is enabled, aligning behavior with the intended single-selection UX.

### New User Features
NA

### New Dev Features
NA

### Improvements
NA

### Bug Fixes
- Prevented the “x of y selected” indicator from rendering when options.singleSelect is true.

### Known Limitations
NA

### Future Steps
NA