### PR TITLE
fix: table flicker after initial load (#87)

### DIFF
--- a/frontend/src/basic/Table.vue
+++ b/frontend/src/basic/Table.vue
@@ -163,7 +163,7 @@
         <tr
           v-for="r in tableData"
           v-else
-          :key="r"
+          :key="r.id"
           @click="selectRow(r)"
         >
           <td v-if="selectableRows">


### PR DESCRIPTION
Closes #87 

## Summary
Fixes the table flicker/jump in the actions column after initial load

## Root cause
The table rows in `BasicTable/Table.vue` used an unstable key (`:key="r"`), where the whole row object was used as the VDOM key.  
Because row objects are recreated during updates, Vue treated rows as new elements and re-rendered them, which caused repeated reflow/flicker in the actions buttons.

## Change
- changed row key from object-based key to stable id-based key:
  - `:key="r"` -> `:key="r.id"`

## Result
- removes the repeated second flicker after initial load
- table updates can still happen in the background, but action buttons no longer reappear

## How to test
1. Open `Dashboard -> Studies` (or `Documents`).
2. Perform a hard refresh of the page.
3. Observe the actions column during the initial load and after switching between dashboard views (`Documents` / `Studies` / `Home`).
4. The buttons should no longer reappear multiple times after the first render.
5. Compare the behavior with the recording in #87 (before the fix).