### PR TITLE
fix: refactor PDF class to use instance state instead of global state

### DIFF
--- a/frontend/src/components/annotator/pdfViewer/pdfStore.js
+++ b/frontend/src/components/annotator/pdfViewer/pdfStore.js
@@ -1,5 +1,4 @@
-// make sure, it's not been reactive!
-const state = {pdf: undefined, pages: {}};
+import { markRaw } from 'vue';
 
 /**
  *  PDF Store
@@ -17,11 +16,12 @@ export class PDF {
 
     constructor(pdf, SIZE = 10) {
         this.BUFFER_SIZE = SIZE;
+        this.state = {pdf: undefined, pages: {}};
     }
 
     reset() {
-        state.pdf = {pdf: undefined};
-        state.pages = {};
+        this.state.pdf = {pdf: undefined};
+        this.state.pages = {};
 
         this.currentBuffer = [];
         this.pageCount = 0;
@@ -32,25 +32,25 @@ export class PDF {
 
     setPDF(pdf) {
         this.reset();
-        state.pdf = pdf;
-        this.pageCount = state.pdf.numPages;
+        this.state.pdf = markRaw(pdf);
+        this.pageCount = this.state.pdf.numPages;
     }
 
     async getPage(pageNumber) {
 
-        if (!(pageNumber in state.pages)) {
+        if (!(pageNumber in this.state.pages)) {
 
             //Buffer handling
             if (this.currentBuffer.length > this.BUFFER_SIZE) {
-                delete state.pages[this.currentBuffer.shift()];
+                delete this.state.pages[this.currentBuffer.shift()];
             }
             this.currentBuffer.push(pageNumber);
 
-            await state.pdf.getPage(pageNumber).then((page) => {
-                state.pages[pageNumber] = page;
+            await this.state.pdf.getPage(pageNumber).then((page) => {
+                this.state.pages[pageNumber] = markRaw(page);
             });
         }
-        return state.pages[pageNumber];
+        return this.state.pages[pageNumber];
     }
 
     async getPageTextContent(pageIndex) {


### PR DESCRIPTION
Refactored the PDF store to use instance-level state instead of module-level shared state. The state object is now initialized in the constructor, allowing each PDF instance to maintain its own independent state. To prevent Vue's reactivity system from wrapping the pdf.js objects (which would break their private fields), markRaw() is applied to both the PDF document and page objects. This maintains the original behavior while improving encapsulation and preventing potential state conflicts between multiple PDF instances.