### PR TITLE
Page visibility logging (issue 164 Gitlab)

### DIFF
--- a/frontend/src/components/annotator/pdfViewer/PDFViewer.vue
+++ b/frontend/src/components/annotator/pdfViewer/PDFViewer.vue
@@ -4,13 +4,13 @@
   </div>
   <div
     v-if="pdf"
-    id="pdfContainer"
+    :id="'pdfContainer-' + documentId"
     class="has-transparent-text-layer"
     @copy="onCopy"
   >
     <!-- Toolbar -->
     <PDFToolbar
-      id="pdfToolbar"
+      :id="'pdfToolbar-' + documentId"
       v-model="toolbarVisible"
       :zoom-form-data="zoomFormData"
       :is-zooming="isZooming"
@@ -25,12 +25,12 @@
       :key="'PDFPageKey' + page"
       :page-number="page"
       :render="renderCheck[page - 1]"
-      class="scrolling-page"
+      :class="'scrolling-page'"
       :zoom-value="scale"
       @update-visibility="updateVisibility"
     />
     <Adder v-if="!readOnly && !componentReadOnly"/>
-  </div>
+         </div>
 </template>
 
 <script>


### PR DESCRIPTION
Fix duplicate page visibility logging when scrolling in PDF viewer

### New User Features
NA

### New Dev Features
NA

### Improvements
- Page visibility is only reported when the set of visible pages actually changes, reducing redundant analytics events.

### Bug Fixes
- Visibility is now logged only when a page is newly added to or removed from the visible set, so duplicate callbacks for the same state no longer produce duplicate logs.

### Known Limitations
NA

### Future Steps
NA