### PR TITLE
Track which user closed a study (issue 167)

### DIFF
--- a/backend/db/models/study.js
+++ b/backend/db/models/study.js
@@ -405,6 +405,14 @@ module.exports = (sequelize, DataTypes) => {
                 await Study.createStudySteps(study, options);
             }, 
             beforeUpdate: async (study, options) => {
+                // Keep close metadata in model layer to avoid transport-specific logic.
+                if (study.changed("closed") && study.closed && !study.userIdClosed) {
+                    const closingUserId = options.context?.currentUserId;
+                    if (closingUserId) {
+                        study.setDataValue("userIdClosed", closingUserId);
+                    }
+                }
+
                 // If this is a study update (not a close operation) and we have stepDocuments
                 if (options.context?.stepDocuments && !study.closed) {
                     await Study.updateStudy(study, options);

--- a/backend/webserver/sockets/app.js
+++ b/backend/webserver/sockets/app.js
@@ -67,16 +67,13 @@ class AppSocket extends Socket {
         let newEntry = null;
         if (("id" in data.data && data.data.id !== 0) &&
             ('deleted' in data.data || 'closed' in data.data || 'public' in data.data || 'end' in data.data)) {
-            
-            // When closing a study, set the userIdClosed to the current user
-            if (data.table === 'study' && 'closed' in data.data && data.data.closed) {
-                data.data.userIdClosed = this.userId;
-            }
-            
             newEntry = await this.models[data.table].updateById(
                 data.data.id,
                 data.data,
-                {context: data.data, transaction: transaction}
+                {
+                    context: {...data.data, currentUserId: this.userId},
+                    transaction: transaction
+                }
             );
             return newEntry.id;
         }
@@ -113,12 +110,18 @@ class AppSocket extends Socket {
             if (!("userId" in data.data)) {
                 data.data.userId = this.userId;
             }
-            newEntry = await this.models[data.table].add(data.data, {context: data.data, transaction: transaction});
+            newEntry = await this.models[data.table].add(data.data, {
+                context: {...data.data, currentUserId: this.userId},
+                transaction: transaction
+            });
         } else {
             newEntry = await this.models[data.table].updateById(
                 data.data.id,
                 data.data,
-                {context: data.data, transaction: transaction}
+                {
+                    context: {...data.data, currentUserId: this.userId},
+                    transaction: transaction
+                }
             );
         }
 

--- a/backend/webserver/sockets/app.js
+++ b/backend/webserver/sockets/app.js
@@ -67,6 +67,12 @@ class AppSocket extends Socket {
         let newEntry = null;
         if (("id" in data.data && data.data.id !== 0) &&
             ('deleted' in data.data || 'closed' in data.data || 'public' in data.data || 'end' in data.data)) {
+            
+            // When closing a study, set the userIdClosed to the current user
+            if (data.table === 'study' && 'closed' in data.data && data.data.closed) {
+                data.data.userIdClosed = this.userId;
+            }
+            
             newEntry = await this.models[data.table].updateById(
                 data.data.id,
                 data.data,

--- a/backend/webserver/sockets/study.js
+++ b/backend/webserver/sockets/study.js
@@ -96,7 +96,7 @@ class StudySocket extends Socket {
 
             try {
 
-                await this.models['study'].updateById(study.id, {closed: true}, {transaction: transaction});
+                await this.models['study'].updateById(study.id, {closed: true, userIdClosed: this.userId}, {transaction: transaction});
                 transaction.afterCommit(() => {
                     this.broadcastTransactionChanges(transaction);
                 });


### PR DESCRIPTION
When a study is closed, the system now records which user performed the close. This supports auditing and reporting (e.g. who closed which study and when).

## New User Features
- NA

## New Dev Features
- NA

## Improvements
- Study close events now include the closing user. Both the study socket (explicit close) and the app socket (generic update with `closed: true`) set `userIdClosed` to the current user before saving.

## Bug Fixes
- NA

## Known Limitations
- NA

## Future Steps
- NA