### PR TITLE
[FIX] Prevent modal overlap when deleting saved templates

### DIFF
--- a/frontend/src/components/dashboard/study/SavedTemplatesModal.vue
+++ b/frontend/src/components/dashboard/study/SavedTemplatesModal.vue
@@ -158,11 +158,12 @@ export default {
       }
     },
     deleteTemplate(template) {
+      this.close();
       this.$refs.deleteConf.open(
         "Delete Template",
         "Are you sure you want to delete this template?",
         "",
-        function (val) {
+        (val) => {
           if (val) {
             this.$socket.emit("appDataUpdate", {
               table: "study",
@@ -186,6 +187,7 @@ export default {
               }
             });
           }
+          this.$nextTick(() => this.open());
         }
       );
     },


### PR DESCRIPTION
Improves the template delete flow by showing only one modal at a time.  
The saved templates modal now hides before confirmation appears, then returns after the action.
### New User Features
- Cleaner delete confirmation flow
- No overlapping modals while deleting templates
### New Dev Features
- None
### Improvements
- Better modal behavior and UX clarity
### Bug Fixes
- Fixed confirmation modal showing on top of the saved templates modal
### Known Limitations
- N/A
### Future Steps
- N/A
