### PR TITLE
Feat 81 copy closed study session

### DIFF
--- a/backend/db/migrations/20260223135300-extend_study_session_parentStudySessionId.js
+++ b/backend/db/migrations/20260223135300-extend_study_session_parentStudySessionId.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.addColumn('study_session', 'parentStudySessionId', {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+      references: {
+        model: 'study_session',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'SET NULL'
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.removeColumn('study_session', 'parentStudySessionId');
+  }
+};

--- a/backend/db/models/annotation.js
+++ b/backend/db/models/annotation.js
@@ -32,25 +32,27 @@ module.exports = (sequelize, DataTypes) => {
          *   - If not provided or empty, copies ALL annotations (default)
          *   - Single object: copies entries matching that condition
          *   - Array of objects: copies entries matching ANY of the conditions (OR logic)
-         * @param {Object} transaction - The database transaction
+         * @param {number|null} targetStudySessionId - Optional study session ID to set for the duplicated annotations (overrides original value)
+         * @param {number|null} targetStudyStepId - Optional study step ID to set for the duplicated annotations (overrides original value)
+         * @param {Object} options - Database options including transaction
          * @returns {Promise<Array>} Array of duplicated annotations with their comments
          * 
          * @example
          * // Copy all annotations (default)
-         * await duplicateAnnotations(1, 2, null, transaction);
+         * await duplicateAnnotations(1, 2, null, null, null, options);
          * 
          * @example
          * // Copy only null entries
-         * await duplicateAnnotations(1, 2, { studySessionId: null, studyStepId: null }, transaction);
+         * await duplicateAnnotations(1, 2, { studySessionId: null, studyStepId: null }, null, null, options);
          * 
          * @example
          * // Copy multiple conditions
          * await duplicateAnnotations(1, 2, [
          *   { studySessionId: null, studyStepId: null },
          *   { studySessionId: 45, studyStepId: 12 }
-         * ], transaction);
+         * ], options);
          */
-        static async duplicateAnnotations(originalDocumentId, duplicatedDocumentId, filters = null, transaction) {
+        static async duplicateAnnotations(originalDocumentId, duplicatedDocumentId, filters = null, targetStudySessionId = null, targetStudyStepId = null, options) {
             // Build where clause: start with documentId
             const whereClause = {
                 documentId: originalDocumentId,
@@ -79,7 +81,7 @@ module.exports = (sequelize, DataTypes) => {
             const originalAnnotations = await this.findAll({
                 where: whereClause,
                 raw: true,
-                transaction
+                transaction: options.transaction
             });
             
             const duplicatedAnnotations = [];
@@ -95,17 +97,21 @@ module.exports = (sequelize, DataTypes) => {
                     selectors: originalAnnotation.selectors,
                     draft: originalAnnotation.draft,
                     anonymous: originalAnnotation.anonymous,
-                    deleted: false
+                    deleted: false,
+                    studySessionId: targetStudySessionId,
+                    studyStepId: targetStudyStepId
                 };
                 
-                const duplicatedAnnotation = await this.add(baseData, {transaction});
+                const duplicatedAnnotation = await this.add(baseData, {transaction: options.transaction});
                 
                 // Duplicate all comments for this annotation
                 await sequelize.models.comment.duplicateComments(
                     originalAnnotation.id,
                     duplicatedAnnotation,
                     filters,
-                    transaction
+                    targetStudySessionId,
+                    targetStudyStepId,
+                    options
                 );
                 
                 duplicatedAnnotations.push(duplicatedAnnotation);

--- a/backend/db/models/comment.js
+++ b/backend/db/models/comment.js
@@ -44,25 +44,27 @@ module.exports = (sequelize, DataTypes) => {
          *   - If not provided or empty, copies ALL comments (default)
          *   - Single object: copies entries matching that condition
          *   - Array of objects: copies entries matching ANY of the conditions (OR logic)
-         * @param {Object} transaction - The database transaction
+         * @param {number|null} targetStudySessionId - Optional study session ID to set for the duplicated comments (overrides original value)
+         * @param {number|null} targetStudyStepId - Optional study step ID to set for the duplicated comments (overrides original value)
+         * @param {Object} options - Database options including transaction
          * @returns {Promise<Array>} Array of duplicated comments
          * 
          * @example
          * // Copy all comments (default)
-         * await duplicateComments(1, dupAnnotation, null, transaction);
+         * await duplicateComments(1, dupAnnotation, null, null, null, options);
          * 
          * @example
          * // Copy only null entries
-         * await duplicateComments(1, dupAnnotation, { studySessionId: null, studyStepId: null }, transaction);
+         * await duplicateComments(1, dupAnnotation, { studySessionId: null, studyStepId: null }, null, null, options);
          * 
          * @example
          * // Copy multiple conditions
          * await duplicateComments(1, dupAnnotation, [
          *   { studySessionId: null, studyStepId: null },
          *   { studySessionId: 45, studyStepId: 12 }
-         * ], transaction);
+         * ], options);
          */
-        static async duplicateComments(originalAnnotationId, duplicatedAnnotation, filters = null, transaction) {
+        static async duplicateComments(originalAnnotationId, duplicatedAnnotation, filters = null, targetStudySessionId = null, targetStudyStepId = null, options) {
             
             // Build where clause for root comments (no parent)
             const whereClause = {
@@ -93,7 +95,7 @@ module.exports = (sequelize, DataTypes) => {
             const originalComments = await this.findAll({
                 where: whereClause,
                 raw: true,
-                transaction
+                transaction: options.transaction
             });
             
             const duplicatedComments = [];
@@ -106,8 +108,10 @@ module.exports = (sequelize, DataTypes) => {
                     duplicatedAnnotation,
                     null,
                     filters,
-                    transaction,
-                    commentIdMap
+                    targetStudySessionId,
+                    targetStudyStepId,
+                    commentIdMap,
+                    options
                 );
                 duplicatedComments.push(...duplicated);
             }
@@ -122,11 +126,13 @@ module.exports = (sequelize, DataTypes) => {
          * @param {Object} duplicatedAnnotation - The duplicated annotation object
          * @param {number|null} newParentCommentId - The ID of the parent comment in the duplicated tree
          * @param {Object|Object[]} filters - Optional where clause conditions for filtering
-         * @param {Object} transaction - The database transaction
+         * @param {number|null} targetStudySessionId - Optional study session ID to set for the duplicated comment (overrides original value)
+         * @param {number|null} targetStudyStepId - Optional study step ID to set for the duplicated comment (overrides original value)
          * @param {Map} commentIdMap - Map to track original to duplicated comment IDs
+         * @param {Object} options - Database options including transaction
          * @returns {Promise<Array>} Array of duplicated comments
          */
-        static async duplicateCommentWithChildren(originalComment, duplicatedAnnotation, newParentCommentId, filters, transaction, commentIdMap) {
+        static async duplicateCommentWithChildren(originalComment, duplicatedAnnotation, newParentCommentId, filters, targetStudySessionId = null, targetStudyStepId = null , commentIdMap, options) {
             // Create base comment data
             const baseData = {
                 userId: originalComment.userId,
@@ -134,13 +140,15 @@ module.exports = (sequelize, DataTypes) => {
                 draft: originalComment.draft,
                 documentId: duplicatedAnnotation.documentId,
                 annotationId: duplicatedAnnotation.id,
+                studySessionId: targetStudySessionId,
+                studyStepId: targetStudyStepId,
                 parentCommentId: newParentCommentId,
                 tags: originalComment.tags,
                 anonymous: originalComment.anonymous,
                 deleted: false
             };
                       
-            const duplicatedComment = await this.add(baseData, {transaction});
+            const duplicatedComment = await this.add(baseData, {transaction: options.transaction});
             commentIdMap.set(originalComment.id, duplicatedComment.id);
             
             const allDuplicated = [duplicatedComment];
@@ -149,14 +157,14 @@ module.exports = (sequelize, DataTypes) => {
             await sequelize.models.comment_vote.duplicateCommentVotes(
                 originalComment.id,
                 duplicatedComment.id,
-                transaction
+                options
             );
             
             // Find and duplicate child comments
             const childComments = await this.getAllByKey(
                 "parentCommentId",
                 originalComment.id,
-                {transaction},
+                {transaction: options.transaction},
                 true
             );
             
@@ -166,8 +174,10 @@ module.exports = (sequelize, DataTypes) => {
                     duplicatedAnnotation,
                     duplicatedComment.id,
                     filters,
-                    transaction,
-                    commentIdMap
+                    targetStudySessionId,
+                    targetStudyStepId,
+                    commentIdMap,
+                    options
                 );
                 allDuplicated.push(...duplicatedChildren);
             }

--- a/backend/db/models/comment_vote.js
+++ b/backend/db/models/comment_vote.js
@@ -30,10 +30,10 @@ module.exports = (sequelize, DataTypes) => {
          * 
          * @param {number} originalCommentId - The ID of the original comment
          * @param {number} duplicatedCommentId - The ID of the duplicated comment
-         * @param {Object} transaction - The database transaction
+         * @param {Object} options - Database options including transaction
          * @returns {Promise<Array>} Array of duplicated comment votes
          */
-        static async duplicateCommentVotes(originalCommentId, duplicatedCommentId, transaction) {
+        static async duplicateCommentVotes(originalCommentId, duplicatedCommentId, options) {
             // Fetch all votes for the original comment
             const originalVotes = await this.findAll({
                 where: {
@@ -41,7 +41,7 @@ module.exports = (sequelize, DataTypes) => {
                     deleted: false
                 },
                 raw: true,
-                transaction
+                transaction: options.transaction
             });
             
             const duplicatedVotes = [];
@@ -55,7 +55,7 @@ module.exports = (sequelize, DataTypes) => {
                     deleted: false
                 };
                 
-                const duplicatedVote = await this.add(duplicateVoteData, {transaction});
+                const duplicatedVote = await this.add(duplicateVoteData, {transaction: options.transaction});
                 duplicatedVotes.push(duplicatedVote);
             }
             

--- a/backend/db/models/document.js
+++ b/backend/db/models/document.js
@@ -82,9 +82,8 @@ module.exports = (sequelize, DataTypes) => {
          * @returns {Promise<Object>} The duplicated document
          */
         static async duplicateDocument(documentId, overrides = {}, filters = {}, options = {}) {
-            const transaction = options.transaction;
-            
-            const originalDoc = await Document.findByPk(documentId, {transaction});
+
+            const originalDoc = await Document.findByPk(documentId, {transaction: options.transaction});
             if (!originalDoc) {
                 throw new Error(`Document with id ${documentId} not found`);
             }
@@ -106,22 +105,67 @@ module.exports = (sequelize, DataTypes) => {
             // Apply overrides using Object.assign
             const duplicateData = Object.assign(baseData, overrides);
 
-            const duplicatedDoc = await this.add(duplicateData, options);
-
-           
+            const duplicatedDoc = await this.add(duplicateData, {transaction: options.transaction});
 
             // Copy document files based on type
-            await this.duplicateDocumentFiles(originalDoc, duplicatedDoc, transaction);
+            await this.duplicateDocumentFiles(originalDoc, duplicatedDoc, options);
 
-            await sequelize.models.document_data.duplicateDocumentData(originalDoc.id, duplicatedDoc.id, filters, transaction);
+            await this.duplicateDocumentData(
+                originalDoc,
+                duplicatedDoc,
+                filters,
+                null,
+                null,
+                options
+            );
 
-            if (originalDoc.type === Document.docTypes.DOC_TYPE_PDF) {
-                await sequelize.models.annotation.duplicateAnnotations(originalDoc.id, duplicatedDoc.id, filters, transaction);
-            }
-            else if(originalDoc.type === Document.docTypes.DOC_TYPE_HTML || originalDoc.type === Document.docTypes.DOC_TYPE_MODAL){
-                await sequelize.models.document_edit.duplicateEditsByDocument(originalDoc.id, duplicatedDoc.id, filters, transaction);
-            }
             return duplicatedDoc;
+        }
+
+        /**
+         * Duplicate all data related to a document (document_data, annotations, document_edit, comments, comment votes)
+         *
+         * @param {Object} originalDocument - The original document object
+         * @param {Object} targetDocument - The target document to copy data to
+         * @param {Object} filters - Optional filters for extra associations (e.g., { studySessionId: 45 })
+         * @param {number|null} targetStudySessionId - Optional study session ID to add the document related data to
+         * @param {number|null} targetStudyStepId - Optional study step ID to add the document related data to
+         * @param {Object} options - Database options including transaction
+         * @returns {Promise<void>}
+         */
+        static async duplicateDocumentData(originalDocument, targetDocument, filters = {}, targetStudySessionId = null, targetStudyStepId = null, options) {
+            // Copy document_data
+            await sequelize.models.document_data.duplicateDocumentData(
+                originalDocument.id, 
+                targetDocument.id, 
+                filters, 
+                targetStudySessionId, 
+                targetStudyStepId, 
+                options
+            );
+
+            // Copy annotations for PDF documents
+            if (originalDocument.type === Document.docTypes.DOC_TYPE_PDF) {
+                await sequelize.models.annotation.duplicateAnnotations(
+                    originalDocument.id, 
+                    targetDocument.id, 
+                    filters, 
+                    targetStudySessionId, 
+                    targetStudyStepId, 
+                    options
+                );
+            }
+            // Copy document edits for HTML/MODAL documents
+            else if (originalDocument.type === Document.docTypes.DOC_TYPE_HTML || originalDocument.type === Document.docTypes.DOC_TYPE_MODAL) {
+                await sequelize.models.document_edit.duplicateEditsByDocument(
+                    originalDocument.id, 
+                    targetDocument.id, 
+                    filters, 
+                    targetStudySessionId, 
+                    targetStudyStepId, 
+                    options
+                );
+            }
         }
 
         /**
@@ -129,9 +173,9 @@ module.exports = (sequelize, DataTypes) => {
          *
          * @param {Object} originalDoc - The original document
          * @param {Object} duplicatedDoc - The duplicated document
-         * @param {Object} transaction - The database transaction
+         * @param {Object} options - Database options including transaction
          */
-        static async duplicateDocumentFiles(originalDoc, duplicatedDoc, transaction) {
+        static async duplicateDocumentFiles(originalDoc, duplicatedDoc, options) {
             if ([Document.docTypes.DOC_TYPE_PDF, Document.docTypes.DOC_TYPE_ZIP].includes(originalDoc.type)) {
                 const docType = originalDoc.type;
                 const docTypeKey = Object.keys(Document.docTypes)

--- a/backend/db/models/document_data.js
+++ b/backend/db/models/document_data.js
@@ -50,20 +50,22 @@ module.exports = (sequelize, DataTypes) => {
          *   - If not provided or empty, copies ALL document data (default)
          *   - Single object: copies entries matching that condition
          *   - Array of objects: copies entries matching ANY of the conditions (OR logic)
-         * @param {Object} transaction - Sequelize transaction object
+         * @param {number|null} targetStudySessionId - Optional study session ID to set for the duplicated data (overrides original value)
+         * @param {number|null} targetStudyStepId - Optional study step ID to set for the duplicated data (overrides original value)
+         * @param {Object} options - Database options including transaction
          * @returns {Promise<void>}
          * 
          * @example
          * // Copy all data (default)
-         * await duplicateDocumentData(1, 2, null, transaction);
+         * await duplicateDocumentData(1, 2, null, null, null, options);
          * 
          * @example
          * // Copy only entries where both studySessionId and studyStepId are null
-         * await duplicateDocumentData(1, 2, { studySessionId: null, studyStepId: null }, transaction);
+         * await duplicateDocumentData(1, 2, { studySessionId: null, studyStepId: null }, null, null, options);
          * 
          * @example
          * // Copy entries with specific studySessionId (regardless of studyStepId)
-         * await duplicateDocumentData(1, 2, { studySessionId: 45 }, transaction);
+         * await duplicateDocumentData(1, 2, { studySessionId: 45 }, null, null, options);
          * 
          * @example
          * // Copy entries matching multiple conditions (OR logic)
@@ -71,9 +73,12 @@ module.exports = (sequelize, DataTypes) => {
          *   { studySessionId: null, studyStepId: null },
          *   { studySessionId: 45, studyStepId: 12 },
          *   { studySessionId: 46 }
-         * ], transaction);
+         * ],
+         * null,
+         * null,
+         *  options);
          */
-        static async duplicateDocumentData(originalDocumentId, duplicateDocumentId, filters = null, transaction) {
+        static async duplicateDocumentData(originalDocumentId, duplicateDocumentId, filters = null, targetStudySessionId = null, targetStudyStepId = null, options) {
 
             // Build where clause: start with documentId
             const whereClause = {
@@ -103,7 +108,7 @@ module.exports = (sequelize, DataTypes) => {
             const originalDataEntries = await this.findAll({
                 where: whereClause,
                 raw: true,
-                transaction
+                transaction: options.transaction
             });       
             // Create new data entries for the duplicated document
             if (originalDataEntries.length > 0) {
@@ -112,12 +117,12 @@ module.exports = (sequelize, DataTypes) => {
                     documentId: duplicateDocumentId, // Set to the new duplicated document ID
                     createdAt: new Date(),
                     updatedAt: new Date(),
-                    studySessionId: null,
-                    studyStepId: null,
+                    studySessionId: targetStudySessionId,
+                    studyStepId: targetStudyStepId,
                     id: undefined,
                     deletedAt: undefined,
                 }));
-                await this.bulkCreate(newDataEntries, {transaction});
+                await this.bulkCreate(newDataEntries, {transaction: options.transaction});
             }
         }
     }

--- a/backend/db/models/document_edit.js
+++ b/backend/db/models/document_edit.js
@@ -66,25 +66,27 @@ module.exports = (sequelize, DataTypes) => {
          *   - If not provided or empty, copies ALL edits (default)
          *   - Single object: copies entries matching that condition
          *   - Array of objects: copies entries matching ANY of the conditions (OR logic)
-         * @param {Object} transaction - The database transaction
+         * @param {number|null} targetStudySessionId - Optional study session ID to set for the duplicated data (overrides original value)
+         * @param {number|null} targetStudyStepId - Optional study step ID to set for the duplicated data (overrides original value)
+         * @param {Object} options - Database options including transaction
          * @returns {Promise<Array>} Array of duplicated document edits
          *
          * @example
          * // Copy all edits (default)
-         * await duplicateEditsByDocument(1, 2, null, transaction);
+         * await duplicateEditsByDocument(1, 2, null, null, null, options);
          *
          * @example
          * // Copy only null entries
-         * await duplicateEditsByDocument(1, 2, { studySessionId: null, studyStepId: null }, transaction);
+         * await duplicateEditsByDocument(1, 2, { studySessionId: null, studyStepId: null }, null, null, options);
          *
          * @example
          * // Copy multiple conditions
          * await duplicateEditsByDocument(1, 2, [
          *   { studySessionId: null, studyStepId: null },
          *   { studySessionId: 45, studyStepId: 12 }
-         * ], transaction);
+         * ], options);
          */
-        static async duplicateEditsByDocument(originalDocumentId, duplicatedDocumentId, filters = null, transaction) {
+        static async duplicateEditsByDocument(originalDocumentId, duplicatedDocumentId, filters = null, targetStudySessionId = null, targetStudyStepId = null, options) {
             // Build where clause: start with documentId and deleted=false
             const whereClause = {
                 documentId: originalDocumentId,
@@ -113,7 +115,7 @@ module.exports = (sequelize, DataTypes) => {
             const originalEdits = await this.findAll({
                 where: whereClause,
                 raw: true,
-                transaction
+                transaction: options.transaction
             });
 
             // Build payloads first
@@ -121,11 +123,11 @@ module.exports = (sequelize, DataTypes) => {
                 ...originalEdit,
                 documentId: duplicatedDocumentId,
                 id: undefined,
-                studySessionId: null,
-                studyStepId: null,
+                studySessionId: targetStudySessionId,
+                studyStepId: targetStudyStepId,
             }));
 
-            return await this.bulkCreate(bulkData, {timestamps: false, transaction});
+            return await this.bulkCreate(bulkData, {timestamps: false, transaction: options.transaction});
 
         }
     }

--- a/backend/db/models/study_session.js
+++ b/backend/db/models/study_session.js
@@ -64,6 +64,57 @@ module.exports = (sequelize, DataTypes) => {
             }
         }
 
+        /**
+         * Duplicate a study session along with its associated data (e.g., documents, edits) for a new user.
+         *
+         * @param {number} studySessionId - The ID of the study session to duplicate.
+         * @param {number} overrides - An object containing any fields to override in the duplicated session (e.g., userId).
+         * @param {Object} options - Additional options for the duplication process, including the database transaction.
+         * @return {Promise<StudySession>} The newly created study session instance.
+         *  @throws {Error} If the original study session is not found or if any database operation fails.
+         */
+        static async duplicateStudySession(studySessionId, overrides= {}, options) {
+            const studySession = await this.getById(studySessionId, {transaction: options.transaction});
+            if (!studySession) {
+                throw new Error('Study session not found');
+            }
+            let data = {
+                studyId: studySession.studyId,
+                userId: null,
+                creatorId: this.userId,
+                studyStepId: studySession.studyStepId,
+                numberSteps: studySession.numberSteps,
+                studyStepIdMax: studySession.studyStepIdMax,
+                parentStudySessionId: studySession.id,
+                start: null,
+                end: null,
+            };
+
+            data = Object.assign(data, overrides);
+            
+            const duplicatedSession = await this.add(data, {transaction: options.transaction});
+
+            const studySteps = await sequelize.models.study_step.getAllByKey("studyId", studySession.studyId, {transaction: options.transaction});
+            
+            //copy document related to the study session
+            for (const studyStep of studySteps) {
+                if (studyStep.documentId) {
+                    const document = await sequelize.models.document.getById(studyStep.documentId, {transaction: options.transaction});
+                    if (document) {
+                        await sequelize.models.document.duplicateDocumentData(
+                            document,
+                            document,
+                            { studySessionId: studySession.id, studyStepId: studyStep.id },
+                            duplicatedSession.id,
+                            studyStep.id,
+                            options
+                        );
+                    }
+                }
+             }
+            return duplicatedSession;
+        }
+
         static associate(models) {
             // define association here
             StudySession.belongsTo(models["study"], {

--- a/backend/db/models/study_session.js
+++ b/backend/db/models/study_session.js
@@ -91,6 +91,7 @@ module.exports = (sequelize, DataTypes) => {
         studyStepId: DataTypes.INTEGER,
         numberSteps: DataTypes.INTEGER,
         studyStepIdMax: DataTypes.INTEGER,
+        parentStudySessionId: DataTypes.INTEGER,
         start: DataTypes.DATE,
         end: DataTypes.DATE,
         updatedAt: DataTypes.DATE,

--- a/backend/db/models/study_session.js
+++ b/backend/db/models/study_session.js
@@ -153,8 +153,11 @@ module.exports = (sequelize, DataTypes) => {
         sequelize: sequelize, modelName: 'study_session', tableName: 'study_session', hooks: {
             beforeCreate: async (studySession, options) => {
 
-                // check for study session availability
-                await StudySession.checkSessionAvailability(studySession.studyId, studySession.userId, options);
+                
+                if(studySession.parentStudySessionId === null){
+                    // check for study session availability
+                    await StudySession.checkSessionAvailability(studySession.studyId, studySession.userId, options);
+                }
 
                 // get first step
                 const firstStep = await sequelize.models.study_step.getFirstStep(studySession.studyId, {transaction:options.transaction});
@@ -167,8 +170,9 @@ module.exports = (sequelize, DataTypes) => {
             beforeUpdate: async (studySession, options) => {
                 // Check if study step changed
                 if (studySession._previousDataValues.studyStepId !== studySession.studyStepId) {
-                    await sequelize.models.study.checkStudyOpen(studySession.studyId);
-
+                    if(studySession.parentStudySessionId === null){
+                        await sequelize.models.study.checkStudyOpen(studySession.studyId, options);
+                    }
                     const studySteps = await sequelize.models.study_step.getAllByKey("studyId", studySession.studyId);
 
                     let stepInPreviousStepPath = false;

--- a/backend/db/models/submission.js
+++ b/backend/db/models/submission.js
@@ -125,11 +125,10 @@ module.exports = (sequelize, DataTypes) => {
          * @returns {Promise<Object>} Object containing copied submission and documents
          */
         static async copySubmission(originalSubmissionId, createdByUserId, submissionOverrides = {}, documentOverrides = {}, filters= {}, options = {}) {
-            const transaction = options.transaction;
 
             // Get the original submission
             const originalSubmission = await Submission.findByPk(originalSubmissionId, {
-                transaction
+                transaction: options.transaction
             });
 
             if (!originalSubmission) {
@@ -150,13 +149,13 @@ module.exports = (sequelize, DataTypes) => {
                     deleted: false,
                     ...submissionOverrides, // Apply submission-specific overrides (e.g., hideInFrontend)
                 },
-                {transaction}
+                {transaction: options.transaction}
             );
 
             // Get all documents associated with the original submission
             const originalDocuments = await sequelize.models.document.findAll({
                 where: {submissionId: originalSubmissionId},
-                transaction
+                transaction: options.transaction
             });
 
             // Copy every associated document and track mapping
@@ -174,7 +173,7 @@ module.exports = (sequelize, DataTypes) => {
                         originalDoc.id,
                         mergedDocumentOverrides,
                         filters,
-                        {transaction}
+                        options
                     );
                     copiedDocuments.push(copiedDoc);
                 } catch (error) {

--- a/backend/webserver/sockets/study_session.js
+++ b/backend/webserver/sockets/study_session.js
@@ -84,10 +84,44 @@ class StudySessionSocket extends Socket {
         await this.sendSessionsByStudyId(data.studyId);
     }
 
+    /**
+     * Duplicates a study session and assigns to user.
+     * This is used to copy a study session for a user when they want to start a new session with the same data.
+     * 
+     * @socketEvent studySessionCopy
+     * @param {object} data The data object containing the study session information and target user IDs.
+     * @param {object} data.studySession The study session object to be duplicated.
+     * @param {number[]} data.userIds An array of user IDs to assign the duplicated session to.
+     * @param {object} options  Configuration for the database operation.
+     * @param {Object} options.transaction A Sequelize DB transaction object to ensure atomicity.
+     * @returns {Promise<StudySessions[]>} A promise that resolves with an array of the newly created study session objects for each target user.
+     */
+    async copyStudySession(data, options) {
+        let studySessions = [];
+        const study = await this.models['study'].getById(data.studySession.studyId);
+        if (study.limitSessionsPerUser !== null) {
+            await this.models["study"].updateById(study.id, {
+                limitSessionsPerUser: study.limitSessionsPerUser + 1 // we only add 1 because there is a list of unique userIds, so the limit of session per user will only ever increase by one.
+            }, {transaction: options.transaction});
+        }   
+         if (study.limitSessions !== null) {
+            await this.models["study"].updateById(study.id, {
+                limitSessions: study.limitSessions + data.userIds.length // we add the length of userIds because we are creating a session for each userId, so the limit of session per user will increase by the number of userIds.
+            }, {transaction: options.transaction});
+        }   
+
+
+        for (const userId of data.userIds){
+            studySessions.push(await this.models["study_session"].duplicateStudySession(data.studySession.id, {userId: userId}, options));
+        }
+        return studySessions;
+    }
+
     async init() {
         this.createSocket("studySessionSubscribe", this.subscribeToStudySession, {}, false)
         this.createSocket("studySessionUnsubscribe", this.unsubscribeFromStudySession, {}, false);
         this.createSocket("studySessionStart", this.startStudySession, {}, true);
+        this.createSocket("studySessionCopy", this.copyStudySession, {}, true);
     }
 }
 

--- a/frontend/src/components/Study.vue
+++ b/frontend/src/components/Study.vue
@@ -385,6 +385,9 @@ export default {
     },
     studyClosed() {
       if (this.study) {
+        if(this.studySession?.parentStudySessionId !== null && this.studySession?.end === null){
+          return false;
+        }
         if (this.study.closed) {
           return true;
         }

--- a/frontend/src/components/dashboard/study/AssignUserStudySessionModal.vue
+++ b/frontend/src/components/dashboard/study/AssignUserStudySessionModal.vue
@@ -1,0 +1,203 @@
+<template>
+  <StepperModal
+      ref="assignUserStepper"
+      :steps="steps"
+      :validation="stepValid"
+      size="xl"
+      @submit="assignUsers">
+    <template #title>
+      <h5 class="modal-title">Assign Users to Study Session</h5>
+    </template>
+
+    <template v-if="!studySession" #error>
+      <p class="text-center text-danger">No study session selected!</p>
+      <p class="text-center">Please select a study session to proceed.</p>
+    </template>
+
+    <template #step-1>
+      <h6 class="text-secondary mb-3">Select Users</h6>
+      <p class="text-muted">Select the users you want to assign to this study session.</p>
+      <BasicTable
+          v-model="selectedUsers"
+          :columns="userTableColumns"
+          :data="userTable"
+          :options="userTableOptions"
+          :max-table-height="400"
+      />
+    </template>
+
+    <template #step-2>
+      <p>
+        Are you sure you want to copy this study session for the following users?
+      </p>
+
+      <div class="container">
+        <div class="row mb-2">
+          <div class="col-3"><strong>Study Session ID:</strong></div>
+          <div class="col-9">{{ studySession?.id }}</div>
+        </div>
+        <div class="row mb-2">
+          <div class="col-3"><strong>Original User:</strong></div>
+          <div class="col-9">{{ originalUserName }}</div>
+        </div>
+        <div class="row mb-2">
+          <div class="col-3"><strong>Selected Users:</strong></div>
+          <div class="col-9">{{ selectedUsers.length }}</div>
+        </div>
+      </div>
+
+      <h6 class="text-secondary mt-3">Users assigned to study session copy:</h6>
+      <ul class="list-group">
+        <li
+            v-for="user in selectedUsers"
+            :key="user.id"
+            class="list-group-item">
+          {{ user.firstName }} {{ user.lastName }}
+          <span class="text-muted">({{ user.userName }})</span>
+        </li>
+      </ul>
+    </template>
+  </StepperModal>
+</template>
+
+<script>
+import BasicTable from "@/basic/Table.vue";
+import StepperModal from "@/basic/modal/StepperModal.vue";
+
+/**
+ * Modal for assigning users to a study session using a stepper
+ * @author: Karim Ouf
+ */
+export default {
+  name: "AssignUserStudySessionModal",
+  subscribeTable: ["user", "study_session"],
+  components: {StepperModal, BasicTable},
+  data() {
+    return {
+      studySession: null,
+      selectedUsers: [],
+      userTableOptions: {
+        striped: true,
+        hover: true,
+        bordered: false,
+        borderless: false,
+        small: false,
+        selectableRows: true,
+        scrollY: true,
+        scrollX: true,
+        onlyOneRowSelectable: false,
+        search: true,
+      },
+    };
+  },
+  computed: {
+    steps() {
+      return [
+        {title: "User Selection"},
+        {title: "Confirmation"},
+      ];
+    },
+    stepValid() {
+      return [
+        this.selectedUsers.length > 0,
+        true,
+      ];
+    },
+    users() {
+      return this.$store.getters["table/user/getAll"];
+    },
+    roles() {
+      return this.$store.getters["admin/getSystemRoles"] || [];
+    },
+    originalUserName() {
+      if (!this.studySession?.userId) return "Unknown";
+      const user = this.$store.getters["table/user/get"](this.studySession.userId);
+      return user ? `${user.firstName} ${user.lastName} (${user.userName})` : "Unknown";
+    },
+    userTable() {
+      return this.users.map((u) => {
+        let newU = {
+          ...u,
+          userName: u.userName || "N/A",
+          firstName: u.firstName || "Unknown",
+          lastName: u.lastName || "Unknown",
+        };
+        newU.rolesNames = (u.roles || [])
+          .map((role) => {
+            const foundRole = (this.roles || []).find((roleObj) => roleObj.id === role);
+            return foundRole ? foundRole.name : null;
+          })
+          .filter(name => name !== null)
+          .join(", ");
+        return newU;
+      });
+    },
+    userRoles() {
+      return [...new Set(this.userTable.flatMap(obj => {
+        return obj.rolesNames.split(/,\s*/).filter(n => n !== "");
+      }))];
+    },
+    userTableColumns() {
+      return [
+        {name: "ID", key: "id"},
+        {name: "Username", key: "userName"},
+        {name: "First Name", key: "firstName", sortable: true},
+        {name: "Last Name", key: "lastName", sortable: true},
+        {
+          name: "Roles",
+          key: "rolesNames",
+          filter: this.userRoles.map(r => ({key: r, name: r})),
+        },
+      ];
+    },
+  },
+  methods: {
+    open(studySession) {
+      this.reset();
+      this.studySession = studySession;
+      this.$socket.emit("studySessionSubscribe", { studyId: this.studySession.studyId });
+      this.$refs.assignUserStepper.open();
+    },
+    close() {
+      if (this.studySession) {
+        this.$socket.emit("studySessionUnsubscribe", { studyId: this.studySession.studyId });
+      }
+      this.$refs.assignUserStepper.close();
+    },
+    reset() {
+      this.selectedUsers = [];
+      this.studySession = null;
+    },
+    assignUsers() {
+      this.$refs.assignUserStepper.setWaiting(true);
+
+      this.$socket.emit("studySessionCopy", {
+        studySession: this.studySession,
+        userIds: this.selectedUsers.map((u) => u.id),
+      }, (res) => {
+        this.$refs.assignUserStepper.setWaiting(false);
+        if (res.success) {
+          this.close();
+          this.eventBus.emit("toast", {
+            title: "Study sessions copied",
+            message: `Successfully copied study session to ${this.selectedUsers.length} user(s).`,
+            variant: "success",
+          });
+        } else {
+          this.eventBus.emit("toast", {
+            title: "Copy failed",
+            message: res.message,
+            variant: "danger",
+          });
+        }
+      });
+    },
+  },
+};
+</script>
+
+<style scoped>
+.list-group-item {
+  cursor: default;
+}
+</style>

--- a/frontend/src/components/dashboard/study/StudySessionTable.vue
+++ b/frontend/src/components/dashboard/study/StudySessionTable.vue
@@ -83,8 +83,15 @@ export default {
             keyMapping: { true: "Yes", false: "No" },
             classMapping: { true: "bg-success", false: "bg-danger" },
           },
-        },
+        }
       ];
+
+      if (this.hasCopiedSessions) {
+        columns.push({
+          name: "Parent Session ID",
+          key: "parentStudySessionId",
+        });
+      }
 
       if (this.currentUserOnly) {
         columns.push({
@@ -225,6 +232,13 @@ export default {
     study() {
       return this.studyId ? this.$store.getters["table/study/get"](this.studyId) : null;
     },
+    hasCopiedSessions() {
+      if (!this.study) return false;
+
+      return this.$store.getters["table/study_session/getByKey"]("studyId", this.studyId).some(
+        (session) => session.parentStudySessionId !== null
+      );
+    },
     studySessions() {
       if (!this.study) return [];
       if(this.showAll) {
@@ -276,14 +290,17 @@ export default {
 
       processedSession.startParsed = this.formatDate(session.start);
       processedSession.finished = session.end !== null;
-
+      processedSession.parentStudySessionId = session.parentStudySessionId ?? "-";
       if (this.currentUserOnly) {
+
+        // True only when study is closed, session is not finished, and was copied from a parent session
+        const canResumeOrStart = this.studyClosed && session.end === null && session.parentStudySessionId !== null;
         processedSession.resumable = this.studyResumable;
-        processedSession.showResumeButton = this.studyResumable && session.start !== undefined  && session.start !== null && !this.studyClosed;
-        processedSession.showDeleteButton =
-          this.userId === this.study.createdByUserId && this.userId !== this.study.userId;
-        processedSession.showStartButton = !session.start && !this.studyClosed;
-        processedSession.showInspectButton = this.studyClosed && this.showClosed
+
+        processedSession.showResumeButton = (this.studyResumable && session.start !== undefined && session.start !== null && !this.studyClosed) || (this.studyResumable && session.start !== undefined && session.start !== null && canResumeOrStart);
+        processedSession.showDeleteButton = this.userId === this.study.createdByUserId && this.userId !== this.study.userId;
+        processedSession.showStartButton = (!session.start && !this.studyClosed) || (!session.start && canResumeOrStart);
+        processedSession.showInspectButton = this.showClosed && !canResumeOrStart;
       } else {
         processedSession.showDeleteButton =
           this.$store.getters["auth/getUserId"] === this.study.createdByUserId || this.$store.getters["auth/isAdmin"];

--- a/frontend/src/components/dashboard/study/StudySessionTable.vue
+++ b/frontend/src/components/dashboard/study/StudySessionTable.vue
@@ -7,11 +7,13 @@
     @action="action"
   />
   <ConfirmModal ref="deleteConf" />
+  <AssignUserModal ref="assignUserModal"/>
 </template>
 
 <script>
 import BasicTable from "@/basic/Table.vue";
 import ConfirmModal from "@/basic/modal/ConfirmModal.vue";
+import AssignUserModal from "@/components/dashboard/study/AssignUserStudySessionModal.vue";
 
 /**
  * Table of study session with management buttons
@@ -22,7 +24,8 @@ import ConfirmModal from "@/basic/modal/ConfirmModal.vue";
  */
 export default {
   name: "StudySessionTable",
-  components: { BasicTable, ConfirmModal },
+  subscribeTable: ["user", "study_session"],
+  components: { BasicTable, ConfirmModal, AssignUserModal },
   props: {
     studyId: {
       type: Number,
@@ -321,6 +324,9 @@ export default {
         case "deleteStudySession":
           this.confirmDelete(data.params);
           break;
+        case "copySession":
+          this.copySession(data.params);
+          break;
       }
     },
     confirmDelete(params) {
@@ -363,6 +369,9 @@ export default {
       } catch (error) {
         this.showErrorToast("Link not copied", "Could not copy study session link to clipboard!");
       }
+    },
+    async copySession(params) {
+      this.$refs.assignUserModal.open(params);
     },
     showSuccessToast(title, message) {
       this.eventBus.emit("toast", {

--- a/frontend/src/components/dashboard/study/StudySessionTable.vue
+++ b/frontend/src/components/dashboard/study/StudySessionTable.vue
@@ -176,7 +176,23 @@ export default {
           }
         });
       }
-      buttons.push({
+      buttons.push(
+        {
+          icon: "copy",
+          options: {
+            iconOnly: true,
+            specifiers: {
+              "btn-outline-secondary": true,
+              "btn-sm": true,
+            },
+          },
+          title: "Copy session",
+          action: "copySession",
+          stats:{
+            studySessionId: "id",
+          }     
+        },
+        {
         icon: "trash",
         options: {
           iconOnly: true,


### PR DESCRIPTION

## description 

This feature introduces the ability to create editable copies of closed study sessions, including their associated data.

Each copied session is linked to its original via `parentStudySessionId`, enabling session versioning and comparison between original and updated data.

The system is also enhanced to always use the latest version of a session (original or copied) when exporting or uploading assessment data to Moodle, ensuring consistency and correctness of exported results.

---

## New User Features

* Ability to copy an existing study session using a “Copy session” action.
* Copied sessions include all original data and assessment information.
* Copied sessions are editable, even if the original session is closed.
* Admins can assign the copied session to a specific user via a modal during the copy process.
* Clear visual indication in the UI that a session is a copy/version.

---

## New Dev Features

* Introduction of `parentStudySessionId` (self-referencing relationship) to support session versioning.
* Extended backend handling for deep-copying session data including assessments.

---

## Improvements


---

## Bug Fixes

---

## Known Limitations

* Exporting study sessions is still not implemented

---

## Future Steps
* Implementing exporting of study session and make sure we use the latest version


---
