### PR TITLE
Update dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,6 @@ docs
 # exclude aux files
 .git
 .idea
+
+# exclude database dumps 
+db_dumps 


### PR DESCRIPTION
adds db_dumps to dockerignore so the db_dumps are not copied into the image context on build (leading to huge image sizes in dockers image list and unnecessary storage congestions) 