### PR TITLE
fix 171 Wrong tooltip for toggle settings 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,8 @@ files/*.zip
 
 # database dumps
 db_dumps/
-
-# backend
+logs/
+# backen
 backend/sessions
 backend/node_modules
 backend/logs

--- a/backend/db/config/config.js
+++ b/backend/db/config/config.js
@@ -3,6 +3,9 @@
  *
  * @author Nils Dycke
  */
+const path = require("path");
+require("dotenv").config({path: path.resolve(__dirname, "../../../.env")});
+
 module.exports = {
     development: {
         username: 'postgres',

--- a/frontend/src/components/dashboard/settings/SettingItem.vue
+++ b/frontend/src/components/dashboard/settings/SettingItem.vue
@@ -33,7 +33,7 @@
                             :checked="setting.value"
                             class="form-check-input" 
                             role="switch" 
-                            title="Activate/Deactivate NLP support"
+                            :title="getBooleanToggleTooltip(setting)"
                             type="checkbox"
                           >
                         </div>
@@ -137,6 +137,10 @@ export default {
     }
   },
   methods: {
+    getBooleanToggleTooltip(setting){
+      const label = (setting.description && setting.description.trim()) || setting.key;
+      return `${label}`;
+    },
     toggleCollapse() {
       this.collapsed = !this.collapsed;
     },


### PR DESCRIPTION
# Wrong tooltip for toggle settings

## What is the error?

The error was that the same tooltip option was being displayed on all the toggle settings in the settings tab. Which does not make sense.

## Where the error was.

This error is seen in `SettingItem.vue`, specifically here.

```
<div v-else-if="setting.type === 'boolean' || setting.type === 'bool'" class="form-check form-switch">
  <input 
    v-model="setting.value" 
    :checked="setting.value"
    class="form-check-input" 
    role="switch" 
    title="Activate/Deactivate NLP support"
    type="checkbox">
```

## The fix

Here, I changed the tile field to evaluate from the description of the settings. Please see the changes to get a clear understanding of what I did. 