### PR TITLE
Feat 227 submissions email notification

### DIFF
--- a/backend/db/migrations/20260406152554-basic-setting-email_template_submission_upload.js
+++ b/backend/db/migrations/20260406152554-basic-setting-email_template_submission_upload.js
@@ -10,6 +10,13 @@ const settings = [
     description:
       'Template type for assignment submission upload/reupload emails to the assignment owner (Email - Submission upload). Leave empty to use default email.',
   },
+  {
+    key: 'email.template.submissionUploadConfirmation',
+    value: '',
+    type: 'number',
+    description:
+      'Template for submission upload confirmation to the submitter (Email - Submission upload). Leave empty to use default email.',
+  },
 ];
 
 module.exports = {

--- a/backend/db/migrations/20260406152625-basic-placeholder-email_template_type_7_submission_upload.js
+++ b/backend/db/migrations/20260406152625-basic-placeholder-email_template_type_7_submission_upload.js
@@ -8,7 +8,7 @@ const placeholders = [
     placeholderKey: 'username',
     placeholderLabel: 'Recipient username',
     placeholderType: 'text',
-    placeholderDescription: 'Assignment owner receiving this notification.',
+    placeholderDescription: 'Recipient username (assignment owner or submitter).',
   },
   {
     type: 7,
@@ -38,6 +38,13 @@ const placeholders = [
     placeholderLabel: 'Submission ID',
     placeholderType: 'text',
     placeholderDescription: 'Internal submission identifier.',
+  },
+  {
+    type: 7,
+    placeholderKey: 'timestamp',
+    placeholderLabel: 'Upload timestamp',
+    placeholderType: 'text',
+    placeholderDescription: 'When the submission was uploaded.',
   },
 ];
 

--- a/backend/db/migrations/20260530135251-extend-setting-displayName-email_templates-type_7.js
+++ b/backend/db/migrations/20260530135251-extend-setting-displayName-email_templates-type_7.js
@@ -1,0 +1,35 @@
+'use strict';
+
+/**
+ * Set displayName, displayGroup, and displaySubsection for submission upload email
+ * template settings (type 7), added after extend-setting-displayName-email_templates.
+ *
+ * @type {import('sequelize-cli').Migration}
+ */
+
+const UPDATES = [
+    { key: 'email.template.submissionUpload', displayName: 'Submission upload (assignment owner)', displayGroup: 'Mail', displaySubsection: 'Email templates' },
+    { key: 'email.template.submissionUploadConfirmation', displayName: 'Submission upload (submitter)', displayGroup: 'Mail', displaySubsection: 'Email templates' },
+];
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        const now = new Date();
+        for (const u of UPDATES) {
+            await queryInterface.sequelize.query(
+                `UPDATE setting SET "displayName" = :dn, "displayGroup" = :dg, "displaySubsection" = :ds, "updatedAt" = :now WHERE key = :k`,
+                { replacements: { dn: u.displayName, dg: u.displayGroup, ds: u.displaySubsection, k: u.key, now } }
+            );
+        }
+    },
+
+    async down(queryInterface, Sequelize) {
+        const now = new Date();
+        for (const u of UPDATES) {
+            await queryInterface.sequelize.query(
+                `UPDATE setting SET "displayName" = NULL, "displayGroup" = NULL, "displaySubsection" = NULL, "updatedAt" = :now WHERE key = :k`,
+                { replacements: { k: u.key, now } }
+            );
+        }
+    },
+};

--- a/backend/utils/emailHelper.js
+++ b/backend/utils/emailHelper.js
@@ -58,6 +58,7 @@ async function getEmailFallbackContent(key, variables = {}) {
  * @param {string} [context.eventLabelLower] - Lowercase label for submission upload fallback
  * @param {number} [context.assignmentId] - Assignment ID (submission upload)
  * @param {number} [context.submissionId] - Submission ID (submission upload)
+ * @param {string} [context.timestamp] - Upload timestamp from submission createdAt (submission upload)
  * @param {Object} models - Database models
  * @param {Object} logger - Logger instance
  * @returns {Promise<{subject: string, body: string, isHtml: boolean}>} Email subject, body, and whether body is HTML

--- a/backend/utils/templateResolver.js
+++ b/backend/utils/templateResolver.js
@@ -100,7 +100,7 @@ async function buildReplacementMap(context, models, options = {}) {
     if (allow("assignmentType") && context.assignmentType) {
         replacements["~assignmentType~"] = context.assignmentType;
     }
-    if (allow("assignmentName") && context.assignmentName) {
+    if (allow("assignmentName") && context.assignmentName != null) {
         replacements["~assignmentName~"] = context.assignmentName;
     }
 
@@ -126,6 +126,9 @@ async function buildReplacementMap(context, models, options = {}) {
     }
     if (allow("submissionId") && context.submissionId != null) {
         replacements["~submissionId~"] = String(context.submissionId);
+    }
+    if (allow("timestamp") && context.timestamp) {
+        replacements["~timestamp~"] = context.timestamp;
     }
 
     return replacements;

--- a/backend/webserver/sockets/document.js
+++ b/backend/webserver/sockets/document.js
@@ -976,17 +976,18 @@ class DocumentSocket extends Socket {
     }
 
     /**
-     * Send submission upload/reupload notification email to assignment owner.
+     * Send submission upload/reupload notification emails to assignment owner and submitter.
      *
      * @author Mohammad Elwan
      * @param {Object} data - The input data for sending the notification
      * @param {number} data.assignmentId - Assignment ID linked to the submission
      * @param {number} data.submissionId - Submission ID that was created/replaced
+     * @param {number} data.submitterUserId - User ID of the person who uploaded
      * @param {string} data.eventType - Upload event type ('first_upload' or 'reupload')
      * @returns {Promise<void>}
      */
     async sendSubmissionUploadEmail(data) {
-        const {assignmentId, submissionId, eventType} = data;
+        const {assignmentId, submissionId, submitterUserId, eventType} = data;
         const assignment = await this.models["assignment"].getById(assignmentId);
         if (!assignment) {
             this.server.logger.warn(`Cannot send submission upload email: assignment ${assignmentId} not found`);
@@ -997,32 +998,67 @@ class DocumentSocket extends Socket {
             return;
         }
 
-        const user = await this.models["user"].getById(assignment.userId);
-        if (!user || !user.email) {
+        const submission = await this.models["submission"].getById(submissionId);
+        const eventLabel = eventType === "reupload" ? "Reuploaded" : "Uploaded";
+        const eventLabelLower = eventType === "reupload" ? "reuploaded" : "uploaded";
+        const emailContext = {
+            assignmentName: assignment.name,
+            assignmentId: assignment.id,
+            submissionId: submission?.id ?? submissionId,
+            eventType: eventLabelLower,
+            eventLabel,
+            eventLabelLower,
+            timestamp: submission?.createdAt
+                ? new Date(submission.createdAt).toLocaleString("en-GB", {
+                    day: "numeric",
+                    month: "long",
+                    year: "numeric",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                })
+                : "",
+        };
+
+        const owner = await this.models["user"].getById(assignment.userId);
+        if (!owner || !owner.email) {
             this.server.logger.warn(`Cannot send submission upload email: assignment owner ${assignment.userId} has no email`);
+        } else {
+            const ownerEmailContent = await getEmailContent(
+                "email.template.submissionUpload",
+                "submissionUpload",
+                {
+                    userId: assignment.userId,
+                    ...emailContext,
+                },
+                this.models,
+                this.logger
+            );
+
+            await this.server.sendMail(owner.email, ownerEmailContent.subject, ownerEmailContent.body, {isHtml: ownerEmailContent.isHtml});
+        }
+
+        if (!submitterUserId || submitterUserId === assignment.userId) {
             return;
         }
 
-        const eventLabel = eventType === "reupload" ? "Reuploaded" : "Uploaded";
-        const eventLabelLower = eventType === "reupload" ? "reuploaded" : "uploaded";
+        const submitter = await this.models["user"].getById(submitterUserId);
+        if (!submitter || !submitter.email) {
+            this.server.logger.warn(`Cannot send submission upload confirmation email: submitter ${submitterUserId} has no email`);
+            return;
+        }
 
-        const emailContent = await getEmailContent(
-            "email.template.submissionUpload",
-            "submissionUpload",
+        const submitterEmailContent = await getEmailContent(
+            "email.template.submissionUploadConfirmation",
+            "submissionUploadConfirmation",
             {
-                userId: assignment.userId,
-                assignmentName: assignment.title,
-                assignmentId,
-                submissionId,
-                eventType: eventLabelLower,
-                eventLabel,
-                eventLabelLower,
+                userId: submitterUserId,
+                ...emailContext,
             },
             this.models,
             this.logger
         );
 
-        await this.server.sendMail(user.email, emailContent.subject, emailContent.body, {isHtml: emailContent.isHtml});
+        await this.server.sendMail(submitter.email, submitterEmailContent.subject, submitterEmailContent.body, {isHtml: submitterEmailContent.isHtml});
     }
 
     /**
@@ -1161,6 +1197,7 @@ class DocumentSocket extends Socket {
                         await this.sendSubmissionUploadEmail({
                             assignmentId,
                             submissionId: submission.id,
+                            submitterUserId: userId,
                             eventType: "first_upload",
                         });
                     } catch (emailError) {
@@ -1288,6 +1325,7 @@ class DocumentSocket extends Socket {
                 await this.sendSubmissionUploadEmail({
                     assignmentId: assignment.id,
                     submissionId: newSubmission.id,
+                    submitterUserId: userId,
                     eventType: "reupload",
                 });
             } catch (emailError) {

--- a/files/email-fallbacks/submissionUploadConfirmation.txt
+++ b/files/email-fallbacks/submissionUploadConfirmation.txt
@@ -1,8 +1,8 @@
-CARE - Submission {{eventLabel}}
+CARE - Submission {{eventLabel}} confirmation
 
 Hello,
 
-An assignment submission has been {{eventLabelLower}}.
+Your assignment submission has been {{eventLabelLower}} successfully.
 
 Assignment: {{assignmentName}}
 Assignment ID: {{assignmentId}}

--- a/frontend/src/components/dashboard/settings/SettingItem.vue
+++ b/frontend/src/components/dashboard/settings/SettingItem.vue
@@ -132,7 +132,7 @@ export default {
     emailTemplates() {
       // Show only the user's own templates (copies count, since copies have userId === currentUser).
       return this.$store.getters["table/template/getAll"]
-        .filter(t => !t.deleted && [1, 2, 3, 6].includes(t.type) && t.userId === this.user?.id)
+        .filter(t => !t.deleted && [1, 2, 3, 6, 7].includes(t.type) && t.userId === this.user?.id)
         .map(t => ({ id: t.id, name: t.name, type: t.type }));
     },
     isEmailTemplateSetting() {
@@ -149,6 +149,7 @@ export default {
       if (["email.template.sessionStart", "email.template.sessionFinish"].includes(key)) return 2;
       if (key === "email.template.assignment") return 3;
       if (key === "email.template.studyClosed") return 6;
+      if (["email.template.submissionUpload", "email.template.submissionUploadConfirmation"].includes(key)) return 7;
       return null;
     },
     filteredEmailTemplates() {
@@ -174,31 +175,6 @@ export default {
         this.$emit("update:value", normalized);
       }
     },
-    getFilteredEmailTemplates(setting) {
-      // Determine template type based on setting key
-      let requiredType = null;
-      if (setting.key === "email.template.passwordReset" || 
-          setting.key === "email.template.verification" || 
-          setting.key === "email.template.registration" ||
-          setting.key === "email.template.twoFactorOtp" ||
-          setting.key === "email.template.passwordResetSuccess") {
-        requiredType = 1; // Email - General
-      } else if (setting.key === "email.template.sessionStart" || 
-                 setting.key === "email.template.sessionFinish") {
-        requiredType = 2; // Email - Study Session
-      } else if (setting.key === "email.template.assignment") {
-        requiredType = 3; // Email - Assignment
-      } else if (setting.key === "email.template.submissionUpload") {
-        requiredType = 7; // Email - Submission upload
-      } else if (setting.key === "email.template.studyClosed") {
-        requiredType = 6; // Email - Study Close
-      }
-      
-      // Filter by type if determined
-      return requiredType !== null 
-        ? this.emailTemplates.filter(t => t.type === requiredType)
-        : this.emailTemplates;
-    }
   }
 };
 </script>

--- a/frontend/src/components/editor/sidebar/TemplateConfigurator.vue
+++ b/frontend/src/components/editor/sidebar/TemplateConfigurator.vue
@@ -191,11 +191,12 @@
             studyName: "The name of the study that was closed.",
           },
           7: { // Email - Submission upload
-            username: "The assignment owner receiving this email (not the user who uploaded).",
+            username: "The person receiving this email (assignment owner or submitter).",
             assignmentName: "The title of the assignment.",
             eventType: "Lowercase sentence text: \"uploaded\" or \"reuploaded\".",
             assignmentId: "Internal assignment ID.",
             submissionId: "Internal submission ID.",
+            timestamp: "When the submission was uploaded.",
           },
         };
 


### PR DESCRIPTION
### Main description

Notify the assignment owner and the submitter by email when a submission is uploaded or re-uploaded for an assignment (when Notify on Submission Upload is enabled on that assignment).
Admins can configure two HTML email templates (type Email – Submission upload) in Settings, one for the assignment owner and one for the submitter, or rely on the disk fallbacks.
Type 7 templates support placeholders including assignment name, IDs, upload event, recipient username, and a new optional timestamp.


### New user features

- Email confirmation to the submitter on first upload and re-upload.
- Assignment setting: Notify on Submission Upload (controls both emails).
- Optional admin-configured templates in Settings:
  - Submission upload (assignment owner)
  - Submission upload (submitter)
- New optional placeholder: timestamp for providing when the submission was uploaded.

