### PR TITLE
fix : skip setup wizard in dev-backend targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ help:
 	@echo "make doc 							Build the documentation"
 	@echo "make dev-build       		  		Build the frontend (make dev-build-frontend) and run the backend in development mode"
 	@echo "make dev-backend      		 		Run backend in development mode"
+	@echo "make dev-backend-wizard            	Run backend in development mode with setup wizard enabled"
 	@echo "make dev-backend-watch  			    Run backend in development mode with nodemon (auto-restart)"
 	@echo "make dev-frontend     		 		Run frontend in development mode"
 	@echo "make dev-build-frontend   		 	Build frontend in development mode"
@@ -100,6 +101,10 @@ dev-build: backend/node_modules/.uptodate build-frontend
 .PHONY: dev-backend
 dev-backend: backend/node_modules/.uptodate
 	cd backend && DEV_SKIP_WIZARD=true npm run start
+
+.PHONY: dev-backend-wizard
+dev-backend-wizard: backend/node_modules/.uptodate
+	cd backend && npm run start
 
 .PHONY: dev-backend-watch
 dev-backend-watch: backend/node_modules/.uptodate

--- a/Makefile
+++ b/Makefile
@@ -99,11 +99,11 @@ dev-build: backend/node_modules/.uptodate build-frontend
 
 .PHONY: dev-backend
 dev-backend: backend/node_modules/.uptodate
-	cd backend && npm run start
+	cd backend && DEV_SKIP_WIZARD=true npm run start
 
 .PHONY: dev-backend-watch
 dev-backend-watch: backend/node_modules/.uptodate
-	cd backend && npm run start:watch
+	cd backend && DEV_SKIP_WIZARD=true npm run start:watch
 
 .PHONY: dev-build-frontend
 dev-build-frontend: frontend/node_modules/.uptodate

--- a/docs/source/for_developers/before_you_start.rst
+++ b/docs/source/for_developers/before_you_start.rst
@@ -137,6 +137,8 @@ a database in a docker container and populates it with the necessary schemas.
 
     ``make dev`` runs with ``DEV_SKIP_WIZARD=true`` for faster iterative development.
     If you need to test the first-time setup flow, use ``make dev-wizard``.
+    For backend-only runs, ``make dev-backend`` and ``make dev-backend-watch`` also skip the wizard,
+    while ``make dev-backend-wizard`` keeps wizard flow enabled.
 
 .. note::
 
@@ -146,7 +148,9 @@ a database in a docker container and populates it with the necessary schemas.
 .. warning::
 
         The ``make dev`` command only works on Linux systems.
-        On Windows, you need to start the frontend and backend separately with ``make dev-frontend`` and ``make dev-backend``.
+        On Windows, you need to start the frontend and backend separately.
+        Use ``make dev-frontend`` + ``make dev-backend`` for wizard-skipped backend runs, or
+        ``make dev-frontend`` + ``make dev-backend-wizard`` to test the first-time setup wizard flow.
 
 Frontend
 ~~~~~~~~~~~~
@@ -196,6 +200,13 @@ After that, the backend can be started with:
     make dev-backend
 
 To enable auto-restart of the backend when server files change, use ``make dev-backend-watch`` (runs ``nodemon``).
+Both commands run with ``DEV_SKIP_WIZARD=true``.
+
+If you want backend-only development with wizard enabled, use:
+
+.. code-block:: bash
+
+    make dev-backend-wizard
 
 To shorten things, both commands can also be executed with ``make dev-build`` at once.
 
@@ -239,9 +250,11 @@ More Commands
     * - ``make dev-wizard``
       - Run frontend (dev) and backend (dev) together, with setup wizard enabled. (Unix only)
     * - ``make dev-backend``
-      - Run backend in development mode.
+      - Run backend in development mode with setup wizard skipped.
+    * - ``make dev-backend-wizard``
+      - Run backend in development mode with setup wizard enabled.
     * - ``make dev-backend-watch``
-      - Run backend in development mode with nodemon (auto-restart on file changes).
+      - Run backend in development mode with nodemon (auto-restart on file changes), setup wizard skipped.
     * - ``make dev-frontend``
       - Run frontend in development mode.
     * - ``make dev-build``


### PR DESCRIPTION
Updates dev backend startup targets to skip the setup wizard by default, while keeping the wizard available through `make dev-wizard`.

## New User Features
None

## New Dev Features
None

## Improvements
- `make dev-backend` and `make dev-backend-watch` now set `DEV_SKIP_WIZARD=true` for faster regular dev startup.

## Bug Fixes
None

## Known Limitations
None

## Future Steps
N/A