### PR TITLE
Fix 230 missing required placeholder hardening

### DIFF
--- a/backend/db/models/template.js
+++ b/backend/db/models/template.js
@@ -1,5 +1,6 @@
 'use strict';
 const MetaModel = require("../MetaModel.js");
+const { assertStableEmailTemplateContent } = require("../../utils/templateResolver");
 
 module.exports = (sequelize, DataTypes) => {
     /**
@@ -470,6 +471,18 @@ module.exports = (sequelize, DataTypes) => {
                         throw new Error(
                             "Cannot make a template non-public once it has been made public"
                         );
+                    }
+
+                    // Email templates must have required placeholders in stable content before publish
+                    if (
+                        template.public === true &&
+                        template._previousDataValues?.public !== true &&
+                        [1, 2, 3, 6, 7].includes(template.type)
+                    ) {
+                        await assertStableEmailTemplateContent(template.id, sequelize.models, {
+                            transaction: options.transaction,
+                            action: "publishing",
+                        });
                     }
 
                     // appDataUpdate / updateData passes callerUserId so hooks can enforce ownership

--- a/backend/utils/templateResolver.js
+++ b/backend/utils/templateResolver.js
@@ -356,8 +356,60 @@ async function getMissingRequiredPlaceholders(content, templateType, models, opt
     return missing;
 }
 
+function formatMissingPlaceholderError(missing, { action = "saving", language } = {}) {
+    const tokens = missing.map((k) => `~${k}~`).join(", ");
+    if (language) {
+        return `This email template must include the required placeholder(s): ${tokens} in ${language} before ${action}. Add them from the toolbar in the template editor.`;
+    }
+    return `This email template must include the required placeholder(s): ${tokens}. Add them from the toolbar before ${action}.`;
+}
+
+/**
+ * Check stable template_content for required placeholders (email types 1, 2, 3, 6, 7).
+ * Used when publishing or assigning a template in Settings.
+ *
+ * @param {number} templateId
+ * @param {Object} models
+ * @param {Object}
+ * @returns {Promise<void>}
+ */
+async function assertStableEmailTemplateContent(templateId, models, options = {}) {
+    const action = options.action || "publishing";
+    const template = await models["template"].getById(templateId, options);
+    if (!template) {
+        throw new Error("Template not found");
+    }
+    if (![1, 2, 3, 6, 7].includes(template.type)) {
+        return;
+    }
+
+    const rows = await models["template_content"].findAll({
+        where: { templateId, deleted: false },
+        raw: true,
+        ...options,
+    });
+
+    if (!rows || rows.length === 0) {
+        const missing = await getMissingRequiredPlaceholders({ ops: [] }, template.type, models, options);
+        if (missing.length > 0) {
+            throw new Error(formatMissingPlaceholderError(missing, { action }));
+        }
+        return;
+    }
+
+    for (const row of rows) {
+        const content = row.content && row.content.ops ? { ops: row.content.ops } : { ops: [] };
+        const missing = await getMissingRequiredPlaceholders(content, template.type, models, options);
+        if (missing.length > 0) {
+            throw new Error(formatMissingPlaceholderError(missing, { action, language: row.language }));
+        }
+    }
+}
+
 module.exports = {
     resolveTemplate,
     resolveTemplateToDelta,
     getMissingRequiredPlaceholders,
+    formatMissingPlaceholderError,
+    assertStableEmailTemplateContent,
 };

--- a/backend/webserver/routes/setup.js
+++ b/backend/webserver/routes/setup.js
@@ -165,6 +165,7 @@ module.exports = function (server) {
             try {
                 const { touchesMailService } = await saveSettings(server.db.models["setting"], settings, {
                     transaction,
+                    models: server.db.models,
                 });
                 await server.db.models["setting"].set("app.setup.wizardCompleted", "true", { transaction });
                 await transaction.commit();

--- a/backend/webserver/sockets/setting.js
+++ b/backend/webserver/sockets/setting.js
@@ -60,6 +60,7 @@ class SettingSocket extends Socket {
 
         const { touchesMailService } = await saveSettings(this.models["setting"], data, {
             transaction: options.transaction,
+            models: this.models,
         });
 
         options.transaction.afterCommit(async () => {

--- a/backend/webserver/sockets/template.js
+++ b/backend/webserver/sockets/template.js
@@ -3,7 +3,12 @@ const Socket = require("../Socket");
 const Delta = require("quill-delta");
 const {Op} = require("sequelize");
 const {dbToDelta} = require("editor-delta-conversion");
-const {resolveTemplate, resolveTemplateToDelta, getMissingRequiredPlaceholders} = require("../../utils/templateResolver");
+const {
+  resolveTemplate,
+  resolveTemplateToDelta,
+  getMissingRequiredPlaceholders,
+  formatMissingPlaceholderError,
+} = require("../../utils/templateResolver");
 
 /**
  * Handle templates through websocket
@@ -500,10 +505,7 @@ class TemplateSocket extends Socket {
           options
         );
         if (missing.length > 0) {
-          const tokens = missing.map((k) => `~${k}~`).join(", ");
-          throw new Error(
-            `This email template must include the required placeholder(s): ${tokens}. Add them from the toolbar before saving.`
-          );
+          throw new Error(formatMissingPlaceholderError(missing, { action: "saving" }));
         }
       }
       return;
@@ -532,10 +534,7 @@ class TemplateSocket extends Socket {
         options
       );
       if (missing.length > 0) {
-        const tokens = missing.map((k) => `~${k}~`).join(", ");
-        throw new Error(
-          `This email template must include the required placeholder(s): ${tokens}. Add them from the toolbar before saving.`
-        );
+        throw new Error(formatMissingPlaceholderError(missing, { action: "saving" }));
       }
     }
 

--- a/backend/webserver/sockets/template.js
+++ b/backend/webserver/sockets/template.js
@@ -116,7 +116,34 @@ class TemplateSocket extends Socket {
 
       if (draftEdits.length > 0) {
         const draftDelta = new Delta(dbToDelta(draftEdits));
-        delta = delta.compose(draftDelta);
+        const composed = delta.compose(draftDelta);
+
+        // Self-heal: drafts left unmerged by a forced URL navigation or tab close
+        // (which bypass the editor's close/discard flow) must not resurface as if saved
+        // when they omit required placeholders. Discard such invalid drafts and fall back
+        // to stable content; valid drafts are still resumed.
+        let composedIsInvalid = false;
+        if ([1, 2, 3, 6, 7].includes(template.type)) {
+          const missing = await getMissingRequiredPlaceholders(
+            { ops: composed.ops },
+            template.type,
+            this.models,
+            options
+          );
+          composedIsInvalid = missing.length > 0;
+        }
+
+        if (composedIsInvalid) {
+          await this.models["template_edit"].update(
+            { deleted: true, deletedAt: new Date() },
+            {
+              where: { templateId: data.templateId, language: data.language, draft: true, deleted: false },
+              transaction: options.transaction,
+            }
+          );
+        } else {
+          delta = composed;
+        }
       }
     }
 
@@ -569,6 +596,42 @@ class TemplateSocket extends Socket {
   }
 
   /**
+   * Discard draft edits for a template language without merging into template_content.
+   *
+   * Used when the user leaves the editor after declining to save invalid content.
+   *
+   * @socketEvent templateDiscardDrafts
+   * @param {Object} data
+   * @param {number} data.templateId Template ID (required)
+   * @param {string} data.language   Language code (required)
+   * @param {Object} options
+   * @param {Object} options.transaction
+   * @returns {Promise<void>}
+   */
+  async discardDrafts(data, options) {
+    if (!data.templateId) throw new Error("Template ID is required");
+    if (!data.language) throw new Error("Language is required");
+
+    const template = await this.models["template"].getById(data.templateId);
+    if (!template) return;
+
+    if (template.userId === this.userId) {
+      await this.models["template_edit"].update(
+        { deleted: true, deletedAt: new Date() },
+        {
+          where: {
+            templateId: data.templateId,
+            language: data.language,
+            draft: true,
+            deleted: false,
+          },
+          transaction: options.transaction,
+        }
+      );
+    }
+  }
+
+  /**
    * Detach a template copy from its source (set sourceId to null).
    * After detachment, the template can be edited like any user-created template.
    *
@@ -707,6 +770,7 @@ class TemplateSocket extends Socket {
     this.createSocket("templateEditContent", this.editContent, {}, true);
     this.createSocket("templateAddLanguageContent", this.addContent, {}, true);
     this.createSocket("templateClose", this.closeTemplate, {}, true);
+    this.createSocket("templateDiscardDrafts", this.discardDrafts, {}, true);
     this.createSocket("templatePlaceholderAdd", this.addPlaceholder, {}, true);
     this.createSocket("templatePlaceholderUpdate", this.updatePlaceholder, {}, true);
     this.createSocket("templatePlaceholderGetAll", this.getAllPlaceholders, {}, false);

--- a/backend/webserver/utils/settingSave.js
+++ b/backend/webserver/utils/settingSave.js
@@ -1,6 +1,43 @@
 "use strict";
 
+const { assertStableEmailTemplateContent } = require("../../utils/templateResolver");
+
 const MAIL_SERVICE_KEY_PREFIX = "system.mailService.";
+
+/**
+ * Reject email.template.* settings that point at a missing or incomplete template.
+ *
+ * @param {Object} models
+ * @param {Object[]} settings
+ * @param {Object} [options]
+ * @returns {Promise<void>}
+ */
+async function validateEmailTemplateSettings(models, settings, options = {}) {
+    if (!Array.isArray(settings)) {
+        return;
+    }
+
+    for (const setting of settings) {
+        if (!setting || typeof setting.key !== "string" || !setting.key.startsWith("email.template.")) {
+            continue;
+        }
+
+        const rawValue = setting.value === null || setting.value === undefined ? "" : String(setting.value).trim();
+        if (rawValue === "" || rawValue === "0") {
+            continue;
+        }
+
+        const templateId = parseInt(rawValue, 10);
+        if (isNaN(templateId) || templateId <= 0) {
+            continue;
+        }
+
+        await assertStableEmailTemplateContent(templateId, models, {
+            ...options,
+            action: "assigning",
+        });
+    }
+}
 
 /**
  * Returns whether a settings payload includes any key under system.mailService.*.
@@ -50,10 +87,14 @@ function normalizeSettingValue(value) {
  * @param {*} settings.value setting value
  * @param {Object} [options] additional options
  * @param {Object} [options.transaction] sequelize transaction
+ * @param {Object} [options.models] full models object for email template validation
  * @returns {Promise<object>} result with touchesMailService flag
  */
 async function saveSettings(Setting, settings, options = {}) {
     const list = Array.isArray(settings) ? settings : [];
+    if (options.models) {
+        await validateEmailTemplateSettings(options.models, list, options);
+    }
     const touchesMailService = payloadTouchesMailService(list);
     for (const setting of list) {
         if (!setting || typeof setting.key !== "string" || setting.key.trim() === "") {

--- a/docs/source/for_developers/frontend/components/editor.rst
+++ b/docs/source/for_developers/frontend/components/editor.rst
@@ -151,6 +151,10 @@ This logic is implemented in:
 
 To persist in-progress edits, the system uses **autosave** (see :ref:`Debounce Behaviour <debounce-ref>`).  
 Autosave runs at defined intervals **and** on specific events, such as when the editor component is unmounted or when the WebSocket connection closes while a document is still open.  
+Before ``documentClose`` on unmount, ``flushPendingEdits`` in ``frontend/src/components/editor/editor/Editor.vue`` cancels the debounce timer and sends any ops still in the client buffer via ``documentEdit``, waiting for the socket callback so the server sees the latest edits. The template editor uses the same pattern in ``TemplateEditor.vue`` before ``templateClose`` (see :ref:`Leaving the template editor <template-editor-leave-ref>` in :doc:`templates`).
+
+For **regular documents** (``studySessionId`` is null), ``documentClose`` then calls ``saveDocument`` to merge draft rows into the ``.delta`` file. For **study documents**, flush still persists session-scoped drafts to ``document_edit``, but ``documentClose`` does not run ``saveDocument``; session drafts remain the store until the study workflow completes.
+
 This ensures that the backend always has the latest state, even if the user navigates away or loses connection unexpectedly.
 
 Additionally, when the WebSocket disconnects, the backend triggers a final save of all open documents by calling ``saveDocument``. This is why the list of open components (like editors) is tracked during mount.

--- a/docs/source/for_developers/frontend/components/templates.rst
+++ b/docs/source/for_developers/frontend/components/templates.rst
@@ -38,8 +38,8 @@ Implementing the Template Editor
 ---------------------------------
 
 The main Editor provides ``templateId`` via ``provide`` and conditionally shows the Placeholders sidebar when the document is a template with placeholders.  
-TemplateEditor and TemplateConfigurator are used inside this Editor when editing a template. When the user saves and closes the editor, draft edits are merged from
-``template_edit`` into ``template_content`` so that the next resolution uses the latest saved content.
+TemplateEditor and TemplateConfigurator are used inside this Editor when editing a template. When the user leaves the editor (e.g. topbar back), draft edits are merged from
+``template_edit`` into ``template_content`` so that the next resolution uses the latest saved content. See :ref:`Leaving the template editor <template-editor-leave-ref>` below.
 
 Location:
 
@@ -54,6 +54,22 @@ Location:
       <TemplateConfigurator />
     </template>
 
+.. _template-editor-leave-ref:
+
+Leaving the template editor (unsaved changes)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Templates use the same debounced autosave as documents (see :ref:`Debounce Behaviour <debounce-ref>`). While editing, ops are stored as drafts in ``template_edit``; stable content used by Settings and email resolution lives in ``template_content``.
+
+**Save-on-leave:** In-app navigation (topbar back, dashboard links) runs ``beforeRouteLeave`` in ``frontend/src/components/Template.vue``. The guard calls ``flushPendingEdits`` on ``TemplateEditor`` (cancels debounce and sends buffered ops), then emits ``templateClose``, which calls ``saveTemplate`` in ``backend/webserver/sockets/template.js`` to merge drafts into ``template_content``.
+
+**Required placeholders:** For email types (1, 2, 3, 6, 7), stable ``template_content`` in every language must include all required placeholders (``getMissingRequiredPlaceholders`` in ``backend/utils/templateResolver.js``). Enforcement points:
+
+- **Editor save:** ``saveTemplate`` rejects merges that omit required placeholders. The user may confirm discard; ``templateDiscardDrafts`` soft-deletes draft rows without updating ``template_content``.
+- **Publish:** The ``template`` model ``beforeUpdate`` hook calls ``assertStableEmailTemplateContent`` when ``public`` becomes ``true``.
+- **Settings:** ``validateEmailTemplateSettings`` in ``backend/webserver/utils/settingSave.js`` runs before persisting ``email.template.*`` keys (missing placeholders in any language row blocks assignment).
+
+**Tab close / full reload:** ``beforeunload`` on ``TemplateEditor`` shows the browser's generic leave warning; the route guard does not run. Orphan drafts may remain until the next visit.
 
 Template Types, Placeholders, and Usage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -92,10 +108,11 @@ Adding a New Template Type or Placeholder
 .. note::
 
    Placeholders marked with ``*`` in the table above are **required** for that type.
-   If a required placeholder is missing from the template text, validation will fail
-   (e.g. publishing or using the template) until it is added. The set of required
-   placeholders is defined in the ``placeholder`` table (``required: true``) and
-   enforced via ``getMissingRequiredPlaceholders`` in ``backend/utils/templateResolver.js``.
+   If a required placeholder is missing from stable content in any language, validation
+   fails on editor save, publish, or Settings assignment until it is added. The set of
+   required placeholders is defined in the ``placeholder`` table (``required: true``) and
+   enforced via ``getMissingRequiredPlaceholders`` and ``assertStableEmailTemplateContent``
+   in ``backend/utils/templateResolver.js``.
 
 Here is a concrete example for adding a new placeholder (e.g. ``studyEndDate`` for type 6):
 

--- a/frontend/src/components/Template.vue
+++ b/frontend/src/components/Template.vue
@@ -27,25 +27,47 @@
     subscribeTable: ["template"],
     components: {Loader, Editor},
     beforeRouteLeave(to, from, next) {
-      const templateEditor = this.$refs.editor?.$refs?.templateEditor;
-      if (!templateEditor || typeof templateEditor.requestClose !== "function") {
-        next();
-        return;
-      }
-      templateEditor.requestClose().then((res) => {
-        if (res && res.success) {
-          next();
-        } else {
-          if (res && !res.success) {
+      this.$nextTick(async () => {
+        const templateEditor = this.$refs.editor?.$refs?.templateEditor;
+        if (
+          !templateEditor
+          || typeof templateEditor.flushPendingEdits !== "function"
+          || typeof templateEditor.requestClose !== "function"
+          || typeof templateEditor.requestDiscard !== "function"
+        ) {
+          next(false);
+          return;
+        }
+        try {
+          await templateEditor.flushPendingEdits();
+          const res = await templateEditor.requestClose();
+          if (res && res.success) {
+            next();
+            return;
+          }
+          const confirmMessage = [
+            "This template is missing required placeholders, so your changes will not be saved.",
+            res?.message || "",
+          ].filter(Boolean).join("\n\n");
+          if (!window.confirm(confirmMessage)) {
+            next(false);
+            return;
+          }
+          const discardRes = await templateEditor.requestDiscard();
+          if (!discardRes || !discardRes.success) {
             this.eventBus.emit("toast", {
-              title: "Template save failed",
-              message: res.message || "",
+              title: "Could not discard template changes",
+              message: discardRes?.message || "",
               variant: "danger",
             });
+            next(false);
+            return;
           }
+          next();
+        } catch {
           next(false);
         }
-      }).catch(() => next(false));
+      });
     },
     props: {
       'templateId': {

--- a/frontend/src/components/Template.vue
+++ b/frontend/src/components/Template.vue
@@ -26,6 +26,10 @@
     name: "TemplateRoute",
     subscribeTable: ["template"],
     components: {Loader, Editor},
+    /**
+     * Save-on-leave: flush pending edits, then merge via templateClose.
+     * On merge failure (e.g. missing required placeholders), confirm discard of drafts.
+     */
     beforeRouteLeave(to, from, next) {
       this.$nextTick(async () => {
         const templateEditor = this.$refs.editor?.$refs?.templateEditor;

--- a/frontend/src/components/Template.vue
+++ b/frontend/src/components/Template.vue
@@ -64,7 +64,7 @@
             return;
           }
           next();
-        } catch {
+        } catch (_error) {
           next(false);
         }
       });

--- a/frontend/src/components/editor/editor/Editor.vue
+++ b/frontend/src/components/editor/editor/Editor.vue
@@ -343,18 +343,70 @@ export default {
     this.eventBus.off("editorInsertText", this.insertTextHandler);
     this.eventBus.off('editorApplyGeneratedFeedback', this.applyGeneratedFeedbackHandler);
 
-    this.$socket.emit("documentClose", {documentId: this.documentId, studySessionId: this.studySessionId}, (res) => {
-      if (!res.success) {
-        this.eventBus.emit("toast", {
-          title: "Document Close Error",
-          message: res.message,
-          variant: "danger",
+    this.flushPendingEdits()
+      .catch(() => {})
+      .finally(() => {
+        this.$socket.emit("documentClose", {documentId: this.documentId, studySessionId: this.studySessionId}, (res) => {
+          if (!res.success) {
+            this.eventBus.emit("toast", {
+              title: "Document Close Error",
+              message: res.message,
+              variant: "danger",
+            });
+          }
         });
-      }
-    });
-    this.$socket.emit("documentUnsubscribe", { documentId: this.documentId });
+        this.$socket.emit("documentUnsubscribe", { documentId: this.documentId });
+      });
   },
   methods: {
+    /**
+     * Persist any pending debounced edits before documentClose.
+     *
+     * The debounce timer may not have fired yet when the editor unmounts. This
+     * cancels the timer and sends buffered ops via documentEdit, waiting for the
+     * socket callback before close (and saveDocument for regular documents).
+     *
+     * @returns {Promise<void>}
+     */
+    flushPendingEdits() {
+      if (this.debouncedProcessDelta) {
+        this.debouncedProcessDelta.cancel();
+      }
+      if (!this.editor || this.deltaBuffer.length === 0) {
+        return Promise.resolve();
+      }
+      const quill = this.editor.getEditor();
+      const combinedDelta = this.deltaBuffer.reduce((acc, delta) => acc.compose(delta), new Delta());
+      const dbOps = deltaToDb(combinedDelta.ops);
+      if (dbOps.length === 0) {
+        this.deltaBuffer = [];
+        return Promise.resolve();
+      }
+      const backup = quill.getContents();
+      return new Promise((resolve) => {
+        this.$socket.emit(
+          "documentEdit",
+          {
+            documentId: this.documentId,
+            studySessionId: this.studySessionId || null,
+            studyStepId: this.studyStepId || null,
+            ops: dbOps,
+          },
+          (res) => {
+            if (!res.success) {
+              quill.setContents(backup);
+              this.eventBus.emit("toast", {
+                title: "Previous edit failed; try again",
+                message: res.message,
+                variant: "danger",
+              });
+            }
+            this.deltaBuffer = [];
+            resolve();
+          }
+        );
+      });
+    },
     isEditorEmpty() {
       if (!this.editor || typeof this.editor.getEditor !== "function") {
         return false;

--- a/frontend/src/components/editor/template/TemplateEditor.vue
+++ b/frontend/src/components/editor/template/TemplateEditor.vue
@@ -343,7 +343,11 @@
       },
       /**
        * Persist any pending debounced edits before close/discard checks.
-       * 
+       *
+       * The debounce timer may not have fired yet when the user leaves (topbar back,
+       * route navigation). This cancels the timer and sends buffered ops via
+       * templateEditContent, waiting for the socket callback before templateClose runs.
+       *
        * @returns {Promise<void>}
        */
       flushPendingEdits() {

--- a/frontend/src/components/editor/template/TemplateEditor.vue
+++ b/frontend/src/components/editor/template/TemplateEditor.vue
@@ -109,6 +109,7 @@
         languageSelectorEl: null,
         languageSelectorClickOutside: null,
         newLanguageModalMessage: "",
+        beforeUnloadHandler: null,
       };
     },
     computed: {
@@ -265,12 +266,22 @@
       }
       
       this.debouncedProcessDelta = debounce(this.processDelta, this.debounceTimeForEdits);
-      
+
+      // Warn before full-page unload (forced URL / tab close) when edits are unsaved,
+      // since the route guard does not run in those cases.
+      this.beforeUnloadHandler = this.handleBeforeUnload;
+      window.addEventListener("beforeunload", this.beforeUnloadHandler);
+
       // Load available languages and content
       this.fetchLanguagesAndLoadContent();
     },
     unmounted() {
       this.eventBus.off("editorInsertText", this.insertTextHandler);
+
+      if (this.beforeUnloadHandler) {
+        window.removeEventListener("beforeunload", this.beforeUnloadHandler);
+        this.beforeUnloadHandler = null;
+      }
 
       // Cleanup language selector
       if (this.languageSelectorClickOutside) {
@@ -279,24 +290,32 @@
       if (this.languageSelectorEl && this.languageSelectorEl.parentNode) {
         this.languageSelectorEl.parentNode.removeChild(this.languageSelectorEl);
       }
-
-      // Save template on close
-      // This triggers merging of draft edits into stable content
-      this.$socket.emit("templateClose", { templateId: this.templateId, language: this.selectedLanguage }, (res) => {
-        if (!res.success) {
-          this.eventBus.emit("toast", {
-            title: "Template save failed",
-            message: res.message || "",
-            variant: "danger"
-          });
-        }
-      });
     },
     methods: {
       /**
-       * Request close/save of the current language. Used by the route guard so navigation
-       * can be blocked when save fails (e.g. missing required placeholders).
-       * @returns {Promise<{ success: boolean, message?: string }>}
+       * Whether the editor content differs from what was last loaded for this language.
+       * @returns {boolean}
+       */
+      hasUnsavedChanges() {
+        if (this.firstVersion === null || !this.editor) {
+          return false;
+        }
+        return this.editor.getEditor().root.innerHTML !== this.firstVersion;
+      },
+      /**
+       * Warn on full-page unload (forced URL navigation / tab close) when there are unsaved edits.
+       * @param {BeforeUnloadEvent} event
+       */
+      handleBeforeUnload(event) {
+        if (this.hasUnsavedChanges()) {
+          event.preventDefault();
+        }
+      },
+      /**
+       * Request close/save of the current language.
+       * Used by the route guard so navigation can be blocked when save fails (e.g. missing required placeholders).
+       * 
+       * @returns {Promise<Object>}
        */
       requestClose() {
         return new Promise((resolve) => {
@@ -304,6 +323,69 @@
             "templateClose",
             { templateId: this.templateId, language: this.selectedLanguage },
             (res) => resolve(res || { success: false })
+          );
+        });
+      },
+      /**
+       * Discard draft edits without merging into template_content.
+       * Used when leaving after invalid content.
+       * 
+       * @returns {Promise<Object>}
+       */
+      requestDiscard() {
+        return new Promise((resolve) => {
+          this.$socket.emit(
+            "templateDiscardDrafts",
+            { templateId: this.templateId, language: this.selectedLanguage },
+            (res) => resolve(res || { success: false })
+          );
+        });
+      },
+      /**
+       * Persist any pending debounced edits before close/discard checks.
+       * 
+       * @returns {Promise<void>}
+       */
+      flushPendingEdits() {
+        if (this.debouncedProcessDelta) {
+          this.debouncedProcessDelta.cancel();
+        }
+        if (!this.editor || this.deltaBuffer.length === 0) {
+          return Promise.resolve();
+        }
+        const quill = this.editor.getEditor();
+        const combinedDelta = this.deltaBuffer.reduce((acc, delta) => acc.compose(delta), new Delta());
+        const dbOps = deltaToDb(combinedDelta.ops);
+        if (dbOps.length === 0) {
+          this.deltaBuffer = [];
+          return Promise.resolve();
+        }
+        const backup = quill.getContents();
+        return new Promise((resolve) => {
+          this.$socket.emit(
+            "templateEditContent",
+            {
+              templateId: this.templateId,
+              language: this.selectedLanguage,
+              ops: dbOps,
+            },
+            (res) => {
+              if (!res.success) {
+                quill.setContents(backup);
+                this.eventBus.emit("toast", {
+                  title: "Previous edit failed; try again",
+                  message: res.message,
+                  variant: "danger",
+                });
+              }
+              const currentVersion = this.editor.getEditor().root.innerHTML;
+              this.$emit("update:data", {
+                firstVersion: this.firstVersion,
+                currentVersion: currentVersion,
+              });
+              this.deltaBuffer = [];
+              resolve();
+            }
           );
         });
       },


### PR DESCRIPTION
### Description
Fixes template editor leave behavior so invalid drafts (e.g. missing required placeholders) are not left behind or shown again after navigation away.

#230 

### New User Features
None
### New Dev Features
None
### Improvements
None
### Bug Fixes

- Warn before leaving the template editor when templateClose fails (missing required placeholders), with option to discard drafts and leave.
- Show a browser warning on tab close or forced URL when there are unsaved edits.
- Drop invalid template drafts on editor load so reopening no longer shows unmerged edits that omit required placeholders.
- Add templateDiscardDrafts socket to soft-delete draft template_edit rows without merging to template_content.

### Known Limitations
None
### Future Steps
N/A