### PR TITLE
Hotfix unsubscribeappdata and session secret

### DIFF
--- a/.env
+++ b/.env
@@ -64,3 +64,6 @@ PG_STATS_MIN_AGE_MS=1000
 #   NOTE: Current SQL has a hard LIMIT 10; change only matters if code is updated
 #   to parameterize the LIMIT.
 PG_STATS_TOP_N=10
+
+# session
+SESSION_SECRET=secretString

--- a/.env.dev
+++ b/.env.dev
@@ -45,3 +45,6 @@ RPC_TEST_PORT=3010
 
 RPC_MOODLE_HOST=moodle_rpc
 RPC_MOODLE_PORT=3011
+
+# session
+SESSION_SECRET=secretString

--- a/.env.main
+++ b/.env.main
@@ -45,3 +45,6 @@ RPC_TEST_PORT=3010
 
 RPC_MOODLE_HOST=moodle_rpc
 RPC_MOODLE_PORT=3011
+
+# session
+SESSION_SECRET=secretString

--- a/.env.test
+++ b/.env.test
@@ -42,3 +42,6 @@ RPC_TEST_PORT=3010
 
 RPC_MOODLE_HOST=moodle_rpc
 RPC_MOODLE_PORT=3011
+
+# session
+SESSION_SECRET=secretString

--- a/backend/webserver/Server.js
+++ b/backend/webserver/Server.js
@@ -293,7 +293,7 @@ module.exports = class Server {
 
         //Session management
         return session({
-            secret: "secretString",
+            secret: process.env.SESSION_SECRET,
             store: dbStore,
             resave: false,
             proxy: true,

--- a/backend/webserver/sockets/app.js
+++ b/backend/webserver/sockets/app.js
@@ -415,7 +415,7 @@ class AppSocket extends Socket {
      */
     async unsubscribeAppData(data, options) {
         // remove subscription from the list
-        if (this.socket.appDataSubscriptions["ids"][data].table) {
+        if (this.socket.appDataSubscriptions["ids"][data]?.table) {
             const tableName = this.socket.appDataSubscriptions["ids"][data].table;
             delete this.socket.appDataSubscriptions["ids"][data];
             this.socket.appDataSubscriptions["tables"][tableName].delete(data);


### PR DESCRIPTION
Two hotfixes for dev:

1. Session secret — was hardcoded as 'secretString' in Server.js. Now read from the SESSION_SECRET env var and added to the env files as a configurable value. Closes #182 
2. unsubscribeAppData crash — threw when given an unknown subscription id (it dereferenced .table on undefined). Guarded with optional chaining so an unknown id safely no-ops. Surfaced via socket profiler, but affects normal use too.