### PR TITLE
Fix non appearing public rows

### DIFF
--- a/backend/db/MetaModel.js
+++ b/backend/db/MetaModel.js
@@ -104,12 +104,12 @@ module.exports = class MetaModel extends Model {
                     }
                 }
             }
-            if (userId && 'userId' in this.getAttributes()) {
-                if ("public" in this.getAttributes()) {
-                    filter[Op.or] = [{userId: userId}, {public: true}];
-                } else {
-                    filter['userId'] = userId;
-                }
+            if ("public" in this.getAttributes()) {
+                filter[Op.or] = userId && userId !== null && 'userId' in this.getAttributes()
+                    ? [{userId: userId}, {public: true}]
+                    : [{public: true}];
+            } else if (userId && 'userId' in this.getAttributes()) {
+                filter['userId'] = userId;
             }
             let options = {where: filter, raw: true};
             if (attributes && attributes.length > 0) {

--- a/backend/webserver/Socket.js
+++ b/backend/webserver/Socket.js
@@ -470,6 +470,11 @@ module.exports = class Socket {
                 rowVisibilityConditions.push({userId});
             }
 
+            // --- Public rows: always visible regardless of ownership or access rights ---
+            if ('public' in model.getAttributes()) {
+                rowVisibilityConditions.push({public: true});
+            }
+
             // --- User-level row filter ---
             if (hasModelUserFilter) {
                 const userFilter = await model.getUserFilter(userId);


### PR DESCRIPTION
##Description

Public rows are now visible to all users regardless of ownership or access rights
Rows marked as `public: true` were silently hidden from users who did not
own the record and had no explicit access-map rights, defeating the purpose
of the public flag entirely.

---

## Improvements

- `getAutoTable` in `MetaModel` now applies a `{ public: true }` OR-condition
  even when `userId` is null, so unauthenticated or unrelated users still
  receive public rows.
- `getFiltersAndAttributes` in `Socket.js` now adds `{ public: true }` to the
  row-visibility OR-conditions for any table that declares a `public` column,
  producing `WHERE (userId = ? OR public = true)` for authenticated users.

---

## Bug Fixes

- **Public rows not visible to non-owners** — rows with `public: true` were
  excluded for users who did not own the record and had no access-map rights
  configured. Only admins and row owners could see them. Fixed by including
  `{ public: true }` in the row-visibility filter in both `getAutoTable`
  and `getFiltersAndAttributes`.
