### PR TITLE
Fix and refactor user related issue

### DIFF
--- a/backend/db/migrations/20260711000000-extend-user-rights-public-info.js
+++ b/backend/db/migrations/20260711000000-extend-user-rights-public-info.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const userRights = [
+  {
+    name: "frontend.dashboard.studies.view.userPublicInfo",
+    description: "access to view public user info (id, userName) in studies",
+  },
+];
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.bulkInsert(
+      "user_right",
+      userRights.map((right) => {
+        right["createdAt"] = new Date();
+        right["updatedAt"] = new Date();
+        return right;
+      }),
+      {}
+    );
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.bulkDelete("user_right", {
+      name: userRights.map((r) => r.name),
+    }, {});
+  }
+};

--- a/backend/db/migrations/20260711000001-extend-role-rights-public-info.js
+++ b/backend/db/migrations/20260711000001-extend-role-rights-public-info.js
@@ -1,0 +1,40 @@
+"use strict";
+
+const roleRights = [
+  {
+    role: "user",
+    userRightName: "frontend.dashboard.studies.view.userPublicInfo",
+  },
+];
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const userRoles = await queryInterface.sequelize.query('SELECT id, name FROM "user_role"', {
+      type: queryInterface.sequelize.QueryTypes.SELECT,
+    });
+
+    const roleNameIdMapping = userRoles.reduce((acc, role) => {
+      acc[role.name] = role.id;
+      return acc;
+    }, {});
+
+    await queryInterface.bulkInsert(
+      "role_right_matching",
+      roleRights.map((right) => ({
+        userRoleId: roleNameIdMapping[right.role],
+        userRightName: right.userRightName,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })),
+      {}
+    );
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.bulkDelete(
+      "role_right_matching",
+      { userRightName: roleRights.map((r) => r.userRightName) },
+      {}
+    );
+  },
+};

--- a/backend/db/models/user.js
+++ b/backend/db/models/user.js
@@ -399,6 +399,7 @@ module.exports = (sequelize, DataTypes) => {
                 {
                     where: {id: userId},
                     returning: true,
+                    individualHooks: true,
                     transaction: options.transaction,
                 }
             );

--- a/backend/db/models/user.js
+++ b/backend/db/models/user.js
@@ -14,6 +14,10 @@ module.exports = (sequelize, DataTypes) => {
                 right: "frontend.dashboard.studies.view.userPrivateInfo",
                 columns: ["firstName", "lastName", "email", "extId"]
             },
+            {
+                right: "frontend.dashboard.studies.view.userPublicInfo",
+                columns:["id", "userName"]
+            }
         ];
 
         /**

--- a/backend/webserver/Socket.js
+++ b/backend/webserver/Socket.js
@@ -507,13 +507,14 @@ module.exports = class Socket {
             }
         }
 
-        // --- Column restrictions from access rights (applied regardless of row logic) ---
-        if (accessRights.length > 0) {
-            allAttributes['include'] = [...new Set(
-                accessRights
-                    .filter(a => a.columns)
-                    .flatMap(a => a.columns)
-            )];
+        // --- Column restrictions from access rights (admins bypass, everyone else is restricted) ---
+        if (!isAdmin && accessRights.length > 0) {
+            const columns = [...new Set(accessRights.filter(a => a.columns).flatMap(a => a.columns))];
+            if (columns.length > 0) {
+                // Pass a plain array so Sequelize restricts to only these columns.
+                // { exclude, include } is NOT the same — include there adds virtual attrs, not restricts.
+                allAttributes = columns;
+            }
         }
 
         // Apply row-visibility: baseFilter AND (condition1 OR condition2 OR ...)
@@ -838,7 +839,7 @@ module.exports = class Socket {
 
             let data = [];
             if (accessRights.length > 0 || await this.isAdmin(userId)) {
-                const attributes = [...new Set(accessRights.flatMap(a => a.columns))];
+                const attributes = [...new Set(accessRights.filter(a => a.columns).flatMap(a => a.columns))];
                 data = await this.models[table].getAutoTable(filter, userId, attributes);
             } else {
                 data = await this.models[table].getAutoTable(filter, userId);

--- a/frontend/src/basic/Table.vue
+++ b/frontend/src/basic/Table.vue
@@ -43,7 +43,7 @@
             </div>
           </th>
           <th
-            v-for="(c, index) in columns"
+            v-for="(c, index) in visibleColumns"
             :key="c.key"
             :ref="'header-' + c.key"
             :class="[
@@ -186,7 +186,7 @@
             </div>
           </td>
           <td
-            v-for="(c, index) in columns"
+            v-for="(c, index) in visibleColumns"
             :key="c.key"
             :class="[
               'width' in c ? 'col-' + c.width : 'col-auto',
@@ -460,7 +460,7 @@ export default {
       );
     },
     emptyColspan() {
-      let colspan = this.columns.length;
+      let colspan = this.visibleColumns.length;
       if (this.selectableRows) {
         colspan += 1;
       }
@@ -549,11 +549,17 @@ export default {
           .map(([k, v]) => ({ [k]: v }))
       );
     },
+    // Hide columns whose key is absent from every row (e.g. fields stripped server-side for the current user's rights).
+    // Keep all columns while data hasn't loaded yet, so the header doesn't flash empty.
+    visibleColumns() {
+      if (!this.data || this.data.length === 0) return this.columns;
+      return this.columns.filter((c) => this.data.some((row) => Object.prototype.hasOwnProperty.call(row, c.key)));
+    },
     hasFixedColumns() {
-      return this.columns.some((c) => ["left", "right"].includes(c.fixed));
+      return this.visibleColumns.some((c) => ["left", "right"].includes(c.fixed));
     },
     hasRightFixedColumns() {
-      return this.columns.some((c) => c.fixed === "right");
+      return this.visibleColumns.some((c) => c.fixed === "right");
     },
     // Determine if manage column should be sticky
     shouldFixManageColumn() {
@@ -562,8 +568,8 @@ export default {
     // Cache the indices to avoid repeated searches
     fixedColumnIndices() {
       return {
-        lastLeft: this.columns.findLastIndex((col) => col.fixed === "left"),
-        firstRight: this.columns.findIndex((col) => col.fixed === "right"),
+        lastLeft: this.visibleColumns.findLastIndex((col) => col.fixed === "left"),
+        firstRight: this.visibleColumns.findIndex((col) => col.fixed === "right"),
       };
     },
     selectedCount() {
@@ -738,7 +744,7 @@ export default {
 
       // Compute left-fixed columns
       let leftOffset = 0;
-      this.columns.forEach((column) => {
+      this.visibleColumns.forEach((column) => {
         if (column.fixed === "left") {
           styles[column.key] = {
             ...baseStyle,
@@ -757,7 +763,7 @@ export default {
       }
 
       // Process right-fixed columns from right to left
-      [...this.columns]
+      [...this.visibleColumns]
         .reverse()
         .filter((c) => c.fixed === "right")
         .forEach((column) => {

--- a/frontend/src/basic/Table.vue
+++ b/frontend/src/basic/Table.vue
@@ -43,7 +43,7 @@
             </div>
           </th>
           <th
-            v-for="(c, index) in visibleColumns"
+            v-for="(c, index) in columns"
             :key="c.key"
             :ref="'header-' + c.key"
             :class="[
@@ -186,7 +186,7 @@
             </div>
           </td>
           <td
-            v-for="(c, index) in visibleColumns"
+            v-for="(c, index) in columns"
             :key="c.key"
             :class="[
               'width' in c ? 'col-' + c.width : 'col-auto',
@@ -460,7 +460,7 @@ export default {
       );
     },
     emptyColspan() {
-      let colspan = this.visibleColumns.length;
+      let colspan = this.columns.length;
       if (this.selectableRows) {
         colspan += 1;
       }
@@ -549,17 +549,11 @@ export default {
           .map(([k, v]) => ({ [k]: v }))
       );
     },
-    // Hide columns whose key is absent from every row (e.g. fields stripped server-side for the current user's rights).
-    // Keep all columns while data hasn't loaded yet, so the header doesn't flash empty.
-    visibleColumns() {
-      if (!this.data || this.data.length === 0) return this.columns;
-      return this.columns.filter((c) => this.data.some((row) => Object.prototype.hasOwnProperty.call(row, c.key)));
-    },
     hasFixedColumns() {
-      return this.visibleColumns.some((c) => ["left", "right"].includes(c.fixed));
+      return this.columns.some((c) => ["left", "right"].includes(c.fixed));
     },
     hasRightFixedColumns() {
-      return this.visibleColumns.some((c) => c.fixed === "right");
+      return this.columns.some((c) => c.fixed === "right");
     },
     // Determine if manage column should be sticky
     shouldFixManageColumn() {
@@ -568,8 +562,8 @@ export default {
     // Cache the indices to avoid repeated searches
     fixedColumnIndices() {
       return {
-        lastLeft: this.visibleColumns.findLastIndex((col) => col.fixed === "left"),
-        firstRight: this.visibleColumns.findIndex((col) => col.fixed === "right"),
+        lastLeft: this.columns.findLastIndex((col) => col.fixed === "left"),
+        firstRight: this.columns.findIndex((col) => col.fixed === "right"),
       };
     },
     selectedCount() {
@@ -744,7 +738,7 @@ export default {
 
       // Compute left-fixed columns
       let leftOffset = 0;
-      this.visibleColumns.forEach((column) => {
+      this.columns.forEach((column) => {
         if (column.fixed === "left") {
           styles[column.key] = {
             ...baseStyle,
@@ -763,7 +757,7 @@ export default {
       }
 
       // Process right-fixed columns from right to left
-      [...this.visibleColumns]
+      [...this.columns]
         .reverse()
         .filter((c) => c.fixed === "right")
         .forEach((column) => {

--- a/frontend/src/components/dashboard/Users.vue
+++ b/frontend/src/components/dashboard/Users.vue
@@ -75,32 +75,27 @@
   <DetailsModal
       v-if="modals.details"
       ref="detailsModal"
-      @update-user="fetchUsers"
       @hide="modals.details = false"
   />
   <RightsModal v-if="modals.rights" ref="rightsModal" @hide="modals.rights = false"/>
   <RightsManagementModal
     v-if="modals.rightsManagement"
     ref="rightsManagementModal"
-    @update-user="fetchUsers"
     @hide="modals.rightsManagement = false"
   />
   <RoleManagementModal
     ref="roleManagementModal"
-    @update-user="fetchUsers"
   />
   <PasswordModal ref="passwordModal" />
   <ImportModal
       v-if="modals.import"
       ref="importModal"
-      @update-user="fetchUsers"
       @hide="modals.import = false"
   />
   <UploadModal v-if="modals.upload" ref="uploadModal" @hide="modals.upload = false"/>
   <UserAddModal
       v-if="modals.userAdd"
       ref="userAddModal"
-      @update-user="fetchUsers"
       @hide="modals.userAdd = false"
   />
   <ConfirmModal v-if="modals.confirm" ref="confirmModal" @hide="modals.confirm = false"/>
@@ -215,7 +210,7 @@ export default {
   },
     users() {
       const activeIds = new Set(this.monitorStats.connectedUsers.map(u => u.userId));
-      return this.$store.getters["admin/getUsersByRole"].map((user) => {
+      return this.$store.getters["table/user/getAll"].map((user) => {
         const isActive = activeIds.has(user.id);
         return {
           ...this.formatUserData(user),
@@ -327,7 +322,6 @@ export default {
   },
   
   mounted() {
-    this.fetchUsers();
     this.$socket.emit("userMonitorSubscribe", {}, (response) => {
         this.$store.commit("admin/SOCKET_monitorStatsUpdate", response);
     });
@@ -367,17 +361,6 @@ export default {
     openConfirmModal(name, message, warning, cb) {
       this.modals.confirm = true;
       this.$nextTick(() => this.$refs.confirmModal?.open(name, message, warning, cb));
-    },
-    fetchUsers() {
-      this.$socket.emit("userGetByRole", {role: this.role}, (response) => {
-        if (!response.success) {
-          this.eventBus.emit("toast", {
-            title: "Error fetching users",
-            message: response.message,
-            variant: "danger",
-          });
-        }
-      });
     },
     formatUserData(user) {
       const formatDate = (date) => (date ? new Date(date).toLocaleDateString() : "-");
@@ -437,7 +420,6 @@ export default {
                     message: "User has been deleted",
                     variant: "success",
                   });
-                  this.fetchUsers();
                 } else {
                   this.eventBus.emit("toast", {
                     title: "User not deleted",

--- a/frontend/src/components/dashboard/users/DetailsModal.vue
+++ b/frontend/src/components/dashboard/users/DetailsModal.vue
@@ -141,7 +141,7 @@ export default {
         roles,
       };
       this.$refs.modal.waiting = true;
-      this.$socket.emit("appDataUpdate", { table: "user", data: { id: userId, ...userData } }, (response) => {
+      this.$socket.emit("userUpdateDetails", { userId, userData }, (response) => {
         if (response.success) {
           this.$refs.modal.waiting = false;
           this.$refs.modal.close();

--- a/frontend/src/components/dashboard/users/DetailsModal.vue
+++ b/frontend/src/components/dashboard/users/DetailsModal.vue
@@ -57,7 +57,6 @@ export default {
   data() {
     return {
       userId: 0,
-      userInfo: {},
       formFields: [
         {
           key: "userName",
@@ -113,6 +112,23 @@ export default {
     systemRoles() {
       return this.$store.getters["admin/getSystemRoles"];
     },
+    userInfo(){
+      const user = this.$store.getters["table/user/get"](this.userId);
+      if (!user) {
+        return {};
+      }
+      const formatDate = (date) => (date ? new Date(date).toLocaleDateString() : "-");
+      return {
+        ...user,
+        roles: (user.roles || [])
+            .map((roleId) => this.systemRoles.find((r) => r.id === roleId)?.name)
+            .filter(Boolean),
+        createdAt: formatDate(user.createdAt),
+        updatedAt: formatDate(user.updatedAt),
+        lastLoginAt: formatDate(user.lastLoginAt),
+        deletedAt: formatDate(user.deletedAt),
+      };
+    },
   },
   mounted() {
     const options = this.systemRoles.map((role) => ({
@@ -125,7 +141,6 @@ export default {
   methods: {
     open(userId) {
       this.userId = userId;
-      this.getUserDetails(userId);
       this.$refs.modal.open();
     },
     submit() {
@@ -157,21 +172,6 @@ export default {
             message: response.message,
             variant: "danger",
           });
-        }
-      });
-    },
-    getUserDetails(userId) {
-      this.$socket.emit("userGetDetails", userId, (res) => {
-        if (res.success) {
-          const userInfo = res["data"];
-          const formatDate = (date) => (date ? new Date(date).toLocaleDateString() : "-");
-          this.userInfo = {
-            ...userInfo,
-            createdAt: formatDate(userInfo.createdAt),
-            updatedAt: formatDate(userInfo.updatedAt),
-            lastLoginAt: formatDate(userInfo.lastLoginAt),
-            deletedAt: formatDate(userInfo.deletedAt),
-          };
         }
       });
     },

--- a/frontend/src/components/dashboard/users/DetailsModal.vue
+++ b/frontend/src/components/dashboard/users/DetailsModal.vue
@@ -54,7 +54,6 @@ import BasicButton from "@/basic/Button.vue";
 export default {
   name: "DetailsModal",
   components: {BasicModal, BasicForm, BasicTable, BasicButton},
-  emits: ["updateUser"],
   data() {
     return {
       userId: 0,
@@ -142,11 +141,10 @@ export default {
         roles,
       };
       this.$refs.modal.waiting = true;
-      this.$socket.emit("userUpdateDetails", {userId, userData}, (response) => {
+      this.$socket.emit("appDataUpdate", { table: "user", data: { id: userId, ...userData } }, (response) => {
         if (response.success) {
           this.$refs.modal.waiting = false;
           this.$refs.modal.close();
-          this.$emit("updateUser");
           this.eventBus.emit("toast", {
             title: "User updated",
             message: "Successfully updated user!",

--- a/frontend/src/components/dashboard/users/ImportModal.vue
+++ b/frontend/src/components/dashboard/users/ImportModal.vue
@@ -169,7 +169,6 @@ import MoodleOptions from "@/basic/form/MoodleOptions.vue";
 export default {
   name: "ImportModal",
   components: { MoodleOptions, StepperModal, BasicButton, BasicIcon, BasicTable },
-  emits: ["updateUser"],
   data() {
     return {
       importType: "csv",
@@ -301,7 +300,6 @@ export default {
         this.updatedUserCount = null;
         this.createdUsers = [];
         this.createdErrors = [];
-        this.$emit("updateUser");
       }
       if (this.importType === "moodle") {
         this.eventBus.emit("resetFormField");

--- a/frontend/src/components/dashboard/users/RightsManagementModal.vue
+++ b/frontend/src/components/dashboard/users/RightsManagementModal.vue
@@ -49,7 +49,6 @@ export default {
     BasicForm,
     BasicTable,
   },
-  emits: ["updateUser"],
   data() {
     return {
       formData: {
@@ -188,7 +187,6 @@ export default {
         variant: "success",
       });
 
-      this.$emit("updateUser");
       this.$refs.stepperModal.setWaiting(false);
       this.$refs.stepperModal.close();
     },

--- a/frontend/src/components/dashboard/users/RoleManagementModal.vue
+++ b/frontend/src/components/dashboard/users/RoleManagementModal.vue
@@ -41,7 +41,6 @@ export default {
   name: "RoleManagementModal",
   components: { BasicModal, BasicForm, BasicButton },
   subscribeTable: ["user_role"],
-  emits: ["update-user"],
   data() {
     return {
       formData: {
@@ -121,7 +120,6 @@ export default {
               message: "Role has been successfully created.",
               variant: "success",
             });
-            this.$emit("update-user");
             this.$refs.modal.close();
           } else {
             this.eventBus.emit("toast", {

--- a/frontend/src/components/dashboard/users/UserCreateModal.vue
+++ b/frontend/src/components/dashboard/users/UserCreateModal.vue
@@ -41,7 +41,6 @@ import BasicForm from "@/basic/Form.vue";
 export default {
   name: "UserAddModal",
   components: {BasicModal, BasicButton, BasicForm},
-  emits: ["updateUser"],
   data() {
     return {
       formFields: [
@@ -117,7 +116,7 @@ export default {
       if (!this.$refs.form.validate()) return;
       this.$refs.modal.waiting = true;
 
-      this.$socket.emit("userCreate", this.formData, (response) => {
+      this.$socket.emit("appDataUpdate", { table: "user", data: this.formData }, (response) => {
         if (response.success) {
           this.eventBus.emit("toast", {
             title: "User Creation Completed",
@@ -125,7 +124,6 @@ export default {
             message: "The user creation was successful",
           });
           this.$refs.modal.close();
-          this.$emit("updateUser");
         } else {
           this.$refs.modal.waiting = false;
           this.eventBus.emit("toast", {

--- a/frontend/src/components/dashboard/users/UserCreateModal.vue
+++ b/frontend/src/components/dashboard/users/UserCreateModal.vue
@@ -116,7 +116,7 @@ export default {
       if (!this.$refs.form.validate()) return;
       this.$refs.modal.waiting = true;
 
-      this.$socket.emit("appDataUpdate", { table: "user", data: this.formData }, (response) => {
+      this.$socket.emit("userCreate", this.formData, (response) => {
         if (response.success) {
           this.eventBus.emit("toast", {
             title: "User Creation Completed",


### PR DESCRIPTION
## Summary

The user dashboard previously fetched data via a bespoke `userGetByRole` socket call and manual `fetchUsers()` refreshes wired into every child modal (`@update-user` events). It also broadcast full user records to every connected client regardless of role, which let non-admins read other users' `firstName`/`lastName`/`email`/`extId`.

This PR migrates the user dashboard onto the standard `appDataUpdate` + broadcast-table paradigm used elsewhere in the app, locks down exactly which columns get broadcast to whom, and fixes a `BasicTable` bug that would otherwise leave columns rendered with blank/missing data for users who aren't sent those fields.

## Changes

**Dashboard refactor**
- `Users.vue` now reads from `table/user/getAll` (the broadcasted table) instead of manually fetching via `userGetByRole` and re-fetching after every mutation. Removed `fetchUsers()` and the `@update-user` listeners on `DetailsModal`, `RightsManagementModal`, `RoleManagementModal`, `ImportModal`, and `UserCreateModal` — updates now arrive automatically through the table broadcast.

**Access control (backend)**
- Added a new right, `frontend.dashboard.studies.view.userPublicInfo`, scoped to `id` and `userName`, so every authenticated user (not just admins) receives a minimal public record for user-picker/attribution UI.
- Added the corresponding migrations granting `userPublicInfo` broadly (`extend-user-rights-public-info.js`, `extend-role-rights-public-info.js`).
- `Socket.js`: admins now always bypass column restriction and get every attribute; non-admins are restricted to the union of columns from their granted access rights. Previously the column restriction applied unconditionally (even to admins) and was assigned onto `allAttributes.include` — for Sequelize, `{ include }` *adds* attributes rather than restricting to them, so the filter was silently not working. Also fixed `getAutoTable`'s attribute list crashing when an access-map entry has no `columns`.

**`BasicTable` (generic fix)**
- Columns are now dropped from rendering when their `key` isn't present on any row in `data`, instead of rendering an empty/blank column. This means any table fed by a rights-filtered broadcast (not just Users) automatically hides columns the current user isn't authorized to see, rather than showing them empty.

## Open question for reviewers

`userPublicInfo` currently exposes just `id` and `userName`. Is that the right minimal set for cross-user visibility (e.g. for assignment/study collaborator pickers), or should anything else be added?

## Test plan
- [ ] Verify non-admin users see only `ID`/`User` columns in the Users table (First/Last Name columns absent, not blank)
- [ ] Verify admins still see all columns including First/Last Name/Email
- [ ] Create/edit/delete a user as admin and confirm the table updates live without a manual refresh
- [ ] Confirm no other `BasicTable` consumers regressed (columns that should show blanks per-row still do; only fully-absent keys are hidden)
