### PR TITLE
fix : skip admin delete on used instances and mark wizard done

### DIFF
--- a/backend/db/migrations/20260119192356-transform-user-admin.js
+++ b/backend/db/migrations/20260119192356-transform-user-admin.js
@@ -2,12 +2,26 @@
 
 const { genSalt, genPwdHash } = require('../../utils/auth');
 
+// True if any non-deleted user has logged in (already-set-up instance).
+async function hasAnyUserLoggedIn(queryInterface) {
+    const rows = await queryInterface.sequelize.query(
+        `SELECT 1 AS present FROM "user"
+         WHERE "lastLoginAt" IS NOT NULL
+           AND "deleted" = false
+         LIMIT 1`,
+        { type: queryInterface.sequelize.QueryTypes.SELECT }
+    );
+    return !!(rows && rows.length > 0);
+}
+
 /**
  * Removes the default admin user created by basic-users so the first admin
  * must be created via the setup wizard. Runs after basic-configuration; all
  * configurations owned by the default admin are first reassigned to Bot (userId 2)
  * to satisfy the configuration.userId FK, then the admin is deleted.
  * POST /auth/setup-admin reassigns those configurations from Bot to the new admin.
+ *
+ * Skip on already-set-up instances (any user with lastLoginAt set).
  *
  * @type {import('sequelize-cli').Migration}
  */
@@ -21,19 +35,32 @@ module.exports = {
         if (!admin) {
             return;
         }
+
+        // Keep default admin and leave configs as-is on old / already-used instances.
+        if (await hasAnyUserLoggedIn(queryInterface)) {
+            return;
+        }
+
         const adminId = admin.id;
         const BOT_USER_ID = 2;
+        const transaction = await queryInterface.sequelize.transaction();
+        try {
+            await queryInterface.sequelize.query(
+                `UPDATE configuration SET "userId" = :botId, "updatedAt" = :now WHERE "userId" = :adminId`,
+                {
+                    replacements: { botId: BOT_USER_ID, adminId, now: new Date() },
+                    type: Sequelize.QueryTypes.UPDATE,
+                    transaction,
+                }
+            );
 
-        await queryInterface.sequelize.query(
-            `UPDATE configuration SET "userId" = :botId, "updatedAt" = :now WHERE "userId" = :adminId`,
-            {
-                replacements: { botId: BOT_USER_ID, adminId, now: new Date() },
-                type: Sequelize.QueryTypes.UPDATE,
-            }
-        );
-
-        await queryInterface.bulkDelete('user_role_matching', { userId: adminId }, {});
-        await queryInterface.bulkDelete('user', { userName: 'admin' }, {});
+            await queryInterface.bulkDelete('user_role_matching', { userId: adminId }, { transaction });
+            await queryInterface.bulkDelete('user', { userName: 'admin' }, { transaction });
+            await transaction.commit();
+        } catch (err) {
+            await transaction.rollback();
+            throw err;
+        }
     },
 
     async down(queryInterface, Sequelize) {

--- a/backend/db/migrations/20260223130010-basic-setting-app_setup.js
+++ b/backend/db/migrations/20260223130010-basic-setting-app_setup.js
@@ -1,13 +1,32 @@
 'use strict';
 
-/** @type {import('sequelize-cli').Migration} */
+// True if any non-deleted user has logged in (matches transform-user-admin guard).
+async function hasAnyUserLoggedIn(queryInterface) {
+    const rows = await queryInterface.sequelize.query(
+        `SELECT 1 AS present FROM "user"
+         WHERE "lastLoginAt" IS NOT NULL
+           AND "deleted" = false
+         LIMIT 1`,
+        { type: queryInterface.sequelize.QueryTypes.SELECT }
+    );
+    return !!(rows && rows.length > 0);
+}
+
+/**
+ * Seed setup-wizard state settings. Mark wizard complete when the instance
+ * already has logged-in users so old installs do not re-enter the wizard.
+ *
+ * @type {import('sequelize-cli').Migration}
+ */
 module.exports = {
     async up(queryInterface, Sequelize) {
         const now = new Date();
+        const wizardCompleted = (await hasAnyUserLoggedIn(queryInterface)) ? 'true' : 'false';
+
         await queryInterface.bulkInsert('setting', [
             {
                 key: 'app.setup.wizardCompleted',
-                value: 'false',
+                value: wizardCompleted,
                 type: 'boolean',
                 description: 'Internal setup wizard completion state.',
                 onlyAdmin: true,


### PR DESCRIPTION
Keeps the default admin on already-used instances (when someone has logged in) and marks the setup wizard complete so old DB dumps can migrate without failing.