### PR TITLE
Fix user dashboard edits

### DIFF
--- a/backend/db/models/user.js
+++ b/backend/db/models/user.js
@@ -389,8 +389,15 @@ module.exports = (sequelize, DataTypes) => {
 
             const UserRoleMatching = User.sequelize.models["user_role_matching"];
 
+            const existingUser = await User.getById(userId, options);
+            if (!existingUser) {
+                throw new Error("User not found");
+            }
+
             const roleIdMap = await User.getRoleIdMap();
-            const [updatedRowsCount] = await User.update(
+            // Profile fields may be unchanged; Sequelize then reports 0 updated rows.
+            // Still continue so role matching runs.
+            await User.update(
                 {
                     firstName: userData.firstName,
                     lastName: userData.lastName,
@@ -403,11 +410,6 @@ module.exports = (sequelize, DataTypes) => {
                     transaction: options.transaction,
                 }
             );
-
-            if (updatedRowsCount === 0) {
-                console.error("Failed to update user: User not found");
-                return;
-            }
 
             // Get current roles
             const currentRoles = await UserRoleMatching.findAll({
@@ -445,6 +447,34 @@ module.exports = (sequelize, DataTypes) => {
                 individualHooks: true,
                 transaction: options.transaction,
             });
+
+            // Rebuild role ids and force a user broadcast that includes `roles`,
+            // so Vuex table/user (and the edit modal checkboxes) stay in sync.
+            const updatedRoleRows = await UserRoleMatching.findAll({
+                where: {userId, deleted: false},
+                attributes: ["userRoleId"],
+                transaction: options.transaction,
+                raw: true,
+            });
+            const roleIds = updatedRoleRows.map((row) => row.userRoleId);
+
+            // individualHooks so this update is queued on transaction.changes (for roles below).
+            await User.update(
+                {rolesUpdatedAt: new Date()},
+                {
+                    where: {id: userId},
+                    individualHooks: true,
+                    transaction: options.transaction,
+                }
+            );
+
+            if (options.transaction && Array.isArray(options.transaction.changes)) {
+                for (const entry of options.transaction.changes) {
+                    if (entry.constructor?.tableName === "user" && Number(entry.id) === Number(userId)) {
+                        entry.dataValues.roles = roleIds;
+                    }
+                }
+            }
         }
 
         /**

--- a/frontend/src/components/dashboard/users/DetailsModal.vue
+++ b/frontend/src/components/dashboard/users/DetailsModal.vue
@@ -11,13 +11,13 @@
     <template #body>
       <BasicForm
           ref="form"
-          v-model="userInfo"
+          v-model="formData"
           :fields="formFields"
       />
       <div class="detail-table-container">
         <BasicTable
             :columns="columns"
-            :data="[userInfo]"
+            :data="[userDetails]"
             :options="options"
             :max-table-height="'60vh'"
         />
@@ -57,6 +57,14 @@ export default {
   data() {
     return {
       userId: 0,
+      formData: {
+        userName: "",
+        firstName: "",
+        lastName: "",
+        email: "",
+        roles: [],
+      },
+      userDetails: {},
       formFields: [
         {
           key: "userName",
@@ -112,23 +120,6 @@ export default {
     systemRoles() {
       return this.$store.getters["admin/getSystemRoles"];
     },
-    userInfo(){
-      const user = this.$store.getters["table/user/get"](this.userId);
-      if (!user) {
-        return {};
-      }
-      const formatDate = (date) => (date ? new Date(date).toLocaleDateString() : "-");
-      return {
-        ...user,
-        roles: (user.roles || [])
-            .map((roleId) => this.systemRoles.find((r) => r.id === roleId)?.name)
-            .filter(Boolean),
-        createdAt: formatDate(user.createdAt),
-        updatedAt: formatDate(user.updatedAt),
-        lastLoginAt: formatDate(user.lastLoginAt),
-        deletedAt: formatDate(user.deletedAt),
-      };
-    },
   },
   mounted() {
     const options = this.systemRoles.map((role) => ({
@@ -139,16 +130,57 @@ export default {
     this.formFields[index].options = options;
   },
   methods: {
+    /**
+     * Open the modal and load a writable draft from the Vuex user row.
+     * @param {number} userId - User id to edit
+     */
     open(userId) {
       this.userId = userId;
+      this.loadFormFromStore(userId);
       this.$refs.modal.open();
+    },
+    /**
+     * Copy store user into local formData / userDetails (draft for editing).
+     * @param {number} userId - User id
+     */
+    loadFormFromStore(userId) {
+      const user = this.$store.getters["table/user/get"](userId);
+      if (!user) {
+        this.formData = {
+          userName: "",
+          firstName: "",
+          lastName: "",
+          email: "",
+          roles: [],
+        };
+        this.userDetails = {};
+        return;
+      }
+      const formatDate = (date) => (date ? new Date(date).toLocaleDateString() : "-");
+      this.formData = {
+        userName: user.userName || "",
+        firstName: user.firstName || "",
+        lastName: user.lastName || "",
+        email: user.email || "",
+        roles: (user.roles || [])
+            .map((roleId) => this.systemRoles.find((r) => r.id === roleId)?.name)
+            .filter(Boolean),
+      };
+      this.userDetails = {
+        acceptTerms: user.acceptTerms,
+        acceptStats: user.acceptStats,
+        lastLoginAt: formatDate(user.lastLoginAt),
+        createdAt: formatDate(user.createdAt),
+        updatedAt: formatDate(user.updatedAt),
+        deletedAt: formatDate(user.deletedAt),
+      };
     },
     submit() {
       if (!this.$refs.form.validate()) {
         return;
       }
       const userId = this.userId;
-      const {firstName, lastName, email, roles} = this.userInfo;
+      const {firstName, lastName, email, roles} = this.formData;
       const userData = {
         firstName,
         lastName,
@@ -176,6 +208,15 @@ export default {
       });
     },
     resetForm() {
+      this.formData = {
+        userName: "",
+        firstName: "",
+        lastName: "",
+        email: "",
+        roles: [],
+      };
+      this.userDetails = {};
+      this.userId = 0;
       this.eventBus.emit("resetFormField");
     },
   },


### PR DESCRIPTION
### Description
User edit in the dashboard did not reliably save profile or role changes; the form was bound to a non-writable store snapshot, and role-only updates aborted when profile fields were unchanged.

### Fix
Use a local formData draft in the edit modal, and in updateUserDetails always apply role changes and broadcast the user with updated roles.