### PR TITLE
fix: align rpc hosts and ports in env config

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -41,10 +41,16 @@ ADDITIONAL_CORS_ORIGINS=https://peer.ukp.informatik.tu-darmstadt.de,https://care
 
 # RPCs
 RPC_TEST_HOST=rpc_test
-RPC_TEST_PORT=3010
+RPC_TEST_PORT=8080
 
-RPC_MOODLE_HOST=moodle_rpc
-RPC_MOODLE_PORT=3011
+RPC_MOODLE_HOST=rpc_moodle
+RPC_MOODLE_PORT=8081
+
+RPC_PDF_HOST=rpc_pdf
+RPC_PDF_PORT=8082
+
+RPC_LITELLM_HOST=rpc_litellm
+RPC_LITELLM_PORT=8083
 
 # session
 SESSION_SECRET=secretString

--- a/.env.main
+++ b/.env.main
@@ -41,10 +41,16 @@ ADDITIONAL_CORS_ORIGINS=https://peer.ukp.informatik.tu-darmstadt.de,https://care
 
 # RPCs
 RPC_TEST_HOST=rpc_test
-RPC_TEST_PORT=3010
+RPC_TEST_PORT=8080
 
-RPC_MOODLE_HOST=moodle_rpc
-RPC_MOODLE_PORT=3011
+RPC_MOODLE_HOST=rpc_moodle
+RPC_MOODLE_PORT=8081
+
+RPC_PDF_HOST=rpc_pdf
+RPC_PDF_PORT=8082
+
+RPC_LITELLM_HOST=rpc_litellm
+RPC_LITELLM_PORT=8083
 
 # session
 SESSION_SECRET=secretString


### PR DESCRIPTION
Align the RPC host and port configuration in .env.main and .env.dev. Add the missing RPC configuration for Moodle, PDF, and LiteLLM services so all services can communicate correctly.