### PR TITLE
fix: Modal close throws Bootstrap "_element is null" error

### DIFF
--- a/frontend/src/basic/Modal.vue
+++ b/frontend/src/basic/Modal.vue
@@ -171,7 +171,7 @@ export default {
   },
   mounted() {
     this.modal = new Modal(this.$refs.Modal);
-    this.$refs.Modal.addEventListener('hide.bs.modal', this.hideEvent);
+    this.$refs.Modal.addEventListener('hidden.bs.modal', this.hideEvent);
     this.$refs.Modal.addEventListener('shown.bs.modal', this.showEvent);
 
     if (this.autoOpen) {
@@ -180,7 +180,7 @@ export default {
   },
   beforeUnmount() {
     if (this.$refs.Modal) {
-      this.$refs.Modal.removeEventListener('hide.bs.modal', this.hideEvent);
+      this.$refs.Modal.removeEventListener('hidden.bs.modal', this.hideEvent);
       this.$refs.Modal.removeEventListener('shown.bs.modal', this.showEvent);
     }
     if (this.modal) {


### PR DESCRIPTION
## Summary

`Modal.vue` listened to `hide.bs.modal` and immediately `$emit('hide')`, so the DOM was destroyed while Bootstrap was still finishing its hide animation. Bootstrap then accessed a disposed `_element`.

Switch the listener from `hide.bs.modal` to `hidden.bs.modal` so we emit only after Bootstrap has fully closed the modal.

## Changes

- `frontend/src/basic/Modal.vue`: use `hidden.bs.modal` for add/remove of `hideEvent`

Closes #206 