### PR TITLE
fix: pdf text selection imprecise after pdfjs v5 upgrade

### DIFF
--- a/frontend/src/components/annotator/pdfViewer/PDFPage.vue
+++ b/frontend/src/components/annotator/pdfViewer/PDFPage.vue
@@ -59,6 +59,7 @@ import * as pdfjsLib from 'pdfjs-dist'
 import {ObserveVisibility} from 'vue3-observe-visibility'
 import debounce from 'lodash.debounce';
 import Highlights from "./Highlights.vue";
+import "pdfjs-dist/web/pdf_viewer.css";
 // import { PDFFindController, EventBus } from "pdfjs-dist/web/pdf_viewer.mjs";
 
 


### PR DESCRIPTION
Fixes imprecise PDF text selection.

Broke in d567a2cf (pdfjs 2.16 → 5.3.31). v5 positions text layer spans via CSS variables (--font-height, --scale-x) where v2 wrote inline styles. The migration never imported pdf.js's stylesheet, so those variables went unread which meant spans rendered at a default font size and drifted from the canvas.

One line: import "pdfjs-dist/web/pdf_viewer.css";