### PR TITLE
upon accessing document, sidebar is close, edits are possible

### DIFF
--- a/frontend/src/basic/Sidebar.vue
+++ b/frontend/src/basic/Sidebar.vue
@@ -205,6 +205,11 @@ export default {
       required: false,
       default: true
     },
+    defaultVisible: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
   },
   emits: ['sidebar-change', 'sidebar-action', 'resize', 'sidebar-visibility-change', 'copy'],
   data() {
@@ -214,7 +219,7 @@ export default {
       minWidth: 200,
       maxWidth: 800,
       sidebarWidth: 400,
-      isSidebarVisible: true,
+      isSidebarVisible: this.defaultVisible,
       sidebarIconHighlight: false,
       numberOfVisibleButtons: 4, //controls how many buttons are shown before collapsing into dropdown
       isFixed: false,
@@ -325,9 +330,12 @@ export default {
     this.originalWidth = this.width;
     this.internalActiveSlot = this.activeSideBar || null;
 
+    if (window.innerWidth <= 900) {
+      this.isSidebarVisible = false;
+    }
+
     this.initDragController();
     this.initHoverController();
-    this.onResize();
     window.addEventListener('resize', this.onResize);
 
     // Emit the current active sidebar view after mount

--- a/frontend/src/components/editor/Editor.vue
+++ b/frontend/src/components/editor/Editor.vue
@@ -27,6 +27,7 @@
           :buttons="sidebarButtons"
           :side-bar-width="350"
           :active-side-bar="defaultActiveSidebar"
+          :default-visible="!!defaultActiveSidebar"
           class="sidebar-container"
           :show-toggle-button="true"
           @sidebar-change="handleSidebarChange"


### PR DESCRIPTION
## Summary

Fixes #322: accessing a document no longer auto-opens the "Version History" sidepanel, so it's editable right away instead of starting in read-only mode.

**Root cause:** the sidebar always opened by default on mount, and because of the use of onResize() everytime. 

**Changes:**
- `Sidebar.vue`: new opt-in `defaultVisible` prop (defaults `true`, no behavior change for existing components like `Annotator.vue`); `mounted()` no longer force-shows the sidebar on wide screens.
- `Editor.vue`: passes `:default-visible="!!defaultActiveSidebar"` so the default is sidebar not visible.