### PR TITLE
fix : clear user cache after role update commit

### DIFF
--- a/backend/db/models/user.js
+++ b/backend/db/models/user.js
@@ -475,6 +475,14 @@ module.exports = (sequelize, DataTypes) => {
                     }
                 }
             }
+
+            // Role rows live on user_role_matching; User.findAll (via getAll) is cached.
+            // Clear after commit so the next dashboard load cannot serve a pre-commit cache entry.
+            options.transaction.afterCommit(() => {
+                if (User.cache) {
+                    User.cache.clear();
+                }
+            });
         }
 
         /**


### PR DESCRIPTION
## Description
Fixes #303: after assigning a role in the Users dashboard, the role disappeared on refresh because `User.getAll` could return a stale in-memory cache after `updateUserDetails` wrote `user_role_matching`. Cache is now cleared on `transaction.afterCommit` so the next load reads fresh roles.

## Improvements
Clear `User.cache` after a successful role update commit so dashboard user rows stay in sync with `user_role_matching`.