### PR TITLE
Feat 335 admin tools

### DIFF
--- a/backend/db/migrations/20260810090011-extend-nav_element-admin_tools.js
+++ b/backend/db/migrations/20260810090011-extend-nav_element-admin_tools.js
@@ -1,0 +1,54 @@
+'use strict';
+
+/**
+ * Add Admin Tools page to the Settings nav group.
+ * Extensible dashboard surface for admin file/system utilities.
+ *
+ * @author Mohammad Elwan
+ */
+
+const navElements = [
+  {
+    name: 'Admin Tools',
+    groupId: 'Settings',
+    icon: 'tools',
+    order: 4,
+    admin: true,
+    path: 'admin_tools',
+    component: 'AdminTools',
+  },
+];
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.bulkInsert(
+      'nav_element',
+      await Promise.all(
+        navElements.map(async (element) => {
+          const groupId = await queryInterface.rawSelect(
+            'nav_group',
+            { where: { name: element.groupId } },
+            ['id']
+          );
+
+          return {
+            ...element,
+            groupId,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          };
+        })
+      ),
+      {}
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.bulkDelete(
+      'nav_element',
+      { name: navElements.map((element) => element.name) },
+      {}
+    );
+  },
+};

--- a/backend/webserver/sockets/document.js
+++ b/backend/webserver/sockets/document.js
@@ -1743,9 +1743,10 @@ class DocumentSocket extends Socket {
     }
 
     /**
-     * Schedule writing a replacement file after the DB transaction commits.
-     * Prepares bytes (and strips embedded PDF annotations) before commit, but only
-     * mutates the live hash path in afterCommit so a rollback cannot leave disk and DB out of sync.
+     * Write a replacement temp file, then rename onto the live hash path after commit.
+     * Temp write happens before commit (failure rolls back annotation deletes). Only the
+     * rename runs in afterCommit. If rename fails after commit, the socket callback fails
+     * so the admin is notified (temp file is left for manual recovery).
      *
      * @author Mohammad Elwan
      * @param {Object} document - The document record
@@ -1755,28 +1756,24 @@ class DocumentSocket extends Socket {
      * @param {Object} options - Additional configuration parameter
      * @param {Object} options.transaction - Sequelize DB transaction options
      * @returns {Promise<void>}
+     * @throws {Error} - If the temp file cannot be written, or if rename fails after commit
      */
     async writeReplacementFile(document, fileData, target, expectedExtension, options) {
         const bytes = await this.prepareReplacementFileBytes(document, fileData, expectedExtension);
         const tempPath = `${target}.replace-tmp`;
+        fs.writeFileSync(tempPath, bytes);
 
         options.transaction.afterCommit(() => {
             try {
-                fs.writeFileSync(tempPath, bytes);
                 fs.renameSync(tempPath, target);
             } catch (err) {
                 this.logger.error(
-                    `Error writing replacement file for document #${document.id}: ${err.message}`
+                    `Error promoting replacement file for document #${document.id}: ${err.message}`
                 );
-                try {
-                    if (fs.existsSync(tempPath)) {
-                        fs.unlinkSync(tempPath);
-                    }
-                } catch (cleanupErr) {
-                    this.logger.error(
-                        `Error cleaning up temp replacement file: ${cleanupErr.message}`
-                    );
-                }
+                throw new Error(
+                    `Annotations were updated but the file could not be replaced for document #${document.id}. ` +
+                    `The new file is at ${tempPath}; rename it to ${target} manually. ${err.message}`
+                );
             }
         });
     }

--- a/backend/webserver/sockets/document.js
+++ b/backend/webserver/sockets/document.js
@@ -1614,6 +1614,131 @@ class DocumentSocket extends Socket {
 
 
     /**
+     * Replace the PDF or ZIP file of an existing document on disk.
+     *
+     * Keeps the same document id and hash. Used by admins to correct a wrong
+     * submission file without creating a new document. For PDFs, existing CARE
+     * annotations and comments on the document are removed.
+     *
+     * @author Mohammad Elwan
+     * @param {Object} data - The input data from the frontend
+     * @param {number} data.documentId - The ID of the document to replace
+     * @param {Buffer} data.file - The binary content of the replacement file
+     * @param {string} data.name - The original filename (used to check the extension)
+     * @param {Object} options - Additional configuration parameter
+     * @param {Object} options.transaction - Sequelize DB transaction options
+     * @returns {Promise<Object>}
+     * @throws {Error} - If the user is not an admin or the file type does not match the document
+     */
+    async replaceDocumentFile(data, options) {
+        if (!(await this.isAdmin())) {
+            throw new Error("You do not have permission to replace document files.");
+        }
+
+        if (!data || !data.file) {
+            throw new Error("No file uploaded");
+        }
+
+        if (!data.documentId) {
+            throw new Error("documentId is required");
+        }
+
+        if (!data.name || typeof data.name !== "string") {
+            throw new Error("File name is required");
+        }
+
+        const document = await this.validateDocument(data.documentId, "id", false);
+        const extensionMap = {
+            [docTypes.DOC_TYPE_PDF]: ".pdf",
+            [docTypes.DOC_TYPE_ZIP]: ".zip",
+        };
+        const expectedExtension = extensionMap[document.type];
+
+        if (!expectedExtension) {
+            throw new Error("Only PDF and ZIP documents can be replaced with this tool.");
+        }
+
+        const fileExtension = data.name.substring(data.name.lastIndexOf(".")).toLowerCase();
+        if (fileExtension !== expectedExtension) {
+            throw new Error(
+                `File type mismatch: document requires ${expectedExtension}, got ${fileExtension || "(none)"}`
+            );
+        }
+
+        if (document.type === docTypes.DOC_TYPE_PDF) {
+            await this.clearDocumentAnnotations(document.id, options);
+        }
+
+        const target = path.join(UPLOAD_PATH, `${document.hash}${expectedExtension}`);
+        await this.writeReplacementFile(document, data.file, target, expectedExtension);
+
+        return {
+            documentId: document.id,
+            hash: document.hash,
+            message: `Replaced ${expectedExtension} file for document #${document.id}.`,
+        };
+    }
+
+    /**
+     * Soft-delete CARE annotations and comments for a document.
+     * Matches the cascade used when a PDF document is deleted.
+     *
+     * @author Mohammad Elwan
+     * @param {number} documentId - The document whose annotations should be removed
+     * @param {Object} options - Additional configuration parameter
+     * @param {Object} options.transaction - Sequelize DB transaction options
+     * @returns {Promise<void>}
+     */
+    async clearDocumentAnnotations(documentId, options) {
+        const annotations = await this.models["annotation"].getAllByKey("documentId", documentId);
+        const uniqueAnnotationIds = [...new Set((annotations || []).map((annotation) => annotation.id))];
+        for (const annotationId of uniqueAnnotationIds) {
+            await this.models["annotation"].deleteById(annotationId, {transaction: options.transaction});
+        }
+
+        const comments = await this.models["comment"].getAllByKey("documentId", documentId);
+        const uniqueCommentIds = [...new Set((comments || []).map((comment) => comment.id))];
+        for (const commentId of uniqueCommentIds) {
+            await this.models["comment"].deleteById(commentId, {transaction: options.transaction});
+        }
+    }
+
+    /**
+     * Write a replacement file to the document's existing hash path.
+     * For PDFs, best-effort strip embedded annotations via PDFRPC (same as documentAdd).
+     *
+     * @author Mohammad Elwan
+     * @param {Object} document - The document record
+     * @param {Buffer} fileData - The uploaded file content
+     * @param {string} target - The filesystem path to overwrite
+     * @param {string} expectedExtension - The expected file extension
+     * @returns {Promise<void>}
+     */
+    async writeReplacementFile(document, fileData, target, expectedExtension) {
+        if (expectedExtension === ".pdf") {
+            try {
+                const {file} = await this.server.rpcs["PDFRPC"].deleteAllAnnotations({
+                    file: fileData,
+                    document,
+                });
+                if (!file) {
+                    throw new Error("Couldn't delete original annotations");
+                }
+                fs.writeFileSync(target, file);
+                return;
+            } catch (annotationRpcErr) {
+                this.logger.error(
+                    "Error deleting annotations during document file replace: " + annotationRpcErr.message
+                );
+                fs.writeFileSync(target, fileData);
+                return;
+            }
+        }
+
+        fs.writeFileSync(target, fileData);
+    }
+
+    /**
      * Subscribe the client's socket to a document-specific communication channel.
      *
      * @param {Object} data The data object containing the document identifier.
@@ -1675,6 +1800,7 @@ class DocumentSocket extends Socket {
         this.createSocket("documentGet", this.getDocument, {}, false);
         this.createSocket("documentCreate", this.createDocument, {}, true);
         this.createSocket("documentAdd", this.addDocument, {}, true);
+        this.createSocket("documentReplaceFile", this.replaceDocumentFile, {}, true);
         this.createSocket("documentUpdate", this.updateDocument, {}, true);
         this.createSocket("documentGetMoodleSubmissions", this.documentGetMoodleSubmissions, {}, false);
         this.createSocket("documentDownloadMoodleSubmissions", this.downloadMoodleSubmissions, {}, false);

--- a/backend/webserver/sockets/document.js
+++ b/backend/webserver/sockets/document.js
@@ -1670,7 +1670,7 @@ class DocumentSocket extends Socket {
         }
 
         const target = path.join(UPLOAD_PATH, `${document.hash}${expectedExtension}`);
-        await this.writeReplacementFile(document, data.file, target, expectedExtension);
+        await this.writeReplacementFile(document, data.file, target, expectedExtension, options);
 
         return {
             documentId: document.id,
@@ -1690,13 +1690,21 @@ class DocumentSocket extends Socket {
      * @returns {Promise<void>}
      */
     async clearDocumentAnnotations(documentId, options) {
-        const annotations = await this.models["annotation"].getAllByKey("documentId", documentId);
+        const annotations = await this.models["annotation"].getAllByKey(
+            "documentId",
+            documentId,
+            {transaction: options.transaction}
+        );
         const uniqueAnnotationIds = [...new Set((annotations || []).map((annotation) => annotation.id))];
         for (const annotationId of uniqueAnnotationIds) {
             await this.models["annotation"].deleteById(annotationId, {transaction: options.transaction});
         }
 
-        const comments = await this.models["comment"].getAllByKey("documentId", documentId);
+        const comments = await this.models["comment"].getAllByKey(
+            "documentId",
+            documentId,
+            {transaction: options.transaction}
+        );
         const uniqueCommentIds = [...new Set((comments || []).map((comment) => comment.id))];
         for (const commentId of uniqueCommentIds) {
             await this.models["comment"].deleteById(commentId, {transaction: options.transaction});
@@ -1704,38 +1712,73 @@ class DocumentSocket extends Socket {
     }
 
     /**
-     * Write a replacement file to the document's existing hash path.
-     * For PDFs, best-effort strip embedded annotations via PDFRPC (same as documentAdd).
+     * Prepare replacement file bytes (best-effort PDFRPC strip for PDFs).
+     *
+     * @author Mohammad Elwan
+     * @param {Object} document - The document record
+     * @param {Buffer} fileData - The uploaded file content
+     * @param {string} expectedExtension - The expected file extension
+     * @returns {Promise<Buffer>} Bytes to write after the DB transaction commits
+     */
+    async prepareReplacementFileBytes(document, fileData, expectedExtension) {
+        if (expectedExtension !== ".pdf") {
+            return fileData;
+        }
+
+        try {
+            const {file} = await this.server.rpcs["PDFRPC"].deleteAllAnnotations({
+                file: fileData,
+                document,
+            });
+            if (!file) {
+                throw new Error("Couldn't delete original annotations");
+            }
+            return file;
+        } catch (annotationRpcErr) {
+            this.logger.error(
+                "Error deleting annotations during document file replace: " + annotationRpcErr.message
+            );
+            return fileData;
+        }
+    }
+
+    /**
+     * Schedule writing a replacement file after the DB transaction commits.
+     * Prepares bytes (and strips embedded PDF annotations) before commit, but only
+     * mutates the live hash path in afterCommit so a rollback cannot leave disk and DB out of sync.
      *
      * @author Mohammad Elwan
      * @param {Object} document - The document record
      * @param {Buffer} fileData - The uploaded file content
      * @param {string} target - The filesystem path to overwrite
      * @param {string} expectedExtension - The expected file extension
+     * @param {Object} options - Additional configuration parameter
+     * @param {Object} options.transaction - Sequelize DB transaction options
      * @returns {Promise<void>}
      */
-    async writeReplacementFile(document, fileData, target, expectedExtension) {
-        if (expectedExtension === ".pdf") {
-            try {
-                const {file} = await this.server.rpcs["PDFRPC"].deleteAllAnnotations({
-                    file: fileData,
-                    document,
-                });
-                if (!file) {
-                    throw new Error("Couldn't delete original annotations");
-                }
-                fs.writeFileSync(target, file);
-                return;
-            } catch (annotationRpcErr) {
-                this.logger.error(
-                    "Error deleting annotations during document file replace: " + annotationRpcErr.message
-                );
-                fs.writeFileSync(target, fileData);
-                return;
-            }
-        }
+    async writeReplacementFile(document, fileData, target, expectedExtension, options) {
+        const bytes = await this.prepareReplacementFileBytes(document, fileData, expectedExtension);
+        const tempPath = `${target}.replace-tmp`;
 
-        fs.writeFileSync(target, fileData);
+        options.transaction.afterCommit(() => {
+            try {
+                fs.writeFileSync(tempPath, bytes);
+                fs.renameSync(tempPath, target);
+            } catch (err) {
+                this.logger.error(
+                    `Error writing replacement file for document #${document.id}: ${err.message}`
+                );
+                try {
+                    if (fs.existsSync(tempPath)) {
+                        fs.unlinkSync(tempPath);
+                    }
+                } catch (cleanupErr) {
+                    this.logger.error(
+                        `Error cleaning up temp replacement file: ${cleanupErr.message}`
+                    );
+                }
+            }
+        });
     }
 
     /**

--- a/docs/source/for_developers/backend/socket.rst
+++ b/docs/source/for_developers/backend/socket.rst
@@ -460,8 +460,9 @@ without creating a new document row.
 - Only PDF and ZIP documents are supported; the upload extension must match the document type
 - For PDFs: soft-deletes existing CARE annotations and comments on that document, and best-effort
   strips embedded PDF annotations via PDFRPC (falls back to the raw upload if strip fails)
-- Destructive disk write runs in ``afterCommit`` (temp file then rename) so a transaction rollback
-  cannot leave the live hash path replaced while annotation deletes are undone
+- Writes ``files/{hash}.{ext}.replace-tmp`` before commit (failure rolls back DB changes); renames
+  onto the live hash path in ``afterCommit``. If rename fails after commit, the socket returns an
+  error so the admin is notified and the temp file is left for manual recovery.
 
 .. _document-create-example:
 

--- a/docs/source/for_developers/backend/socket.rst
+++ b/docs/source/for_developers/backend/socket.rst
@@ -445,6 +445,24 @@ In these cases, you can register a manual `afterCommit` hook on the transaction 
    When using ``autoTable`` models, commit-time change tracking and ``<table>Refresh`` emits are automatic.
    Details in :ref:`Store Updates & <table>Refresh> Events <table-refresh-events>`.
 
+.. _document-replace-file:
+
+documentReplaceFile
+~~~~~~~~~~~~~~~~~~~
+
+Admin-only socket used by the Admin Tools dashboard to correct a wrong PDF or ZIP on disk
+without creating a new document row.
+
+- Event name: ``documentReplaceFile``
+- Registered with ``createSocket(..., true)`` (transactional)
+- Input: ``documentId``, ``file`` (binary), ``name`` (original filename for extension checks)
+- Keeps the same document ``id`` and ``hash``; overwrites ``files/{hash}.pdf`` or ``files/{hash}.zip``
+- Only PDF and ZIP documents are supported; the upload extension must match the document type
+- For PDFs: soft-deletes existing CARE annotations and comments on that document, and best-effort
+  strips embedded PDF annotations via PDFRPC (falls back to the raw upload if strip fails)
+- Destructive disk write runs in ``afterCommit`` (temp file then rename) so a transaction rollback
+  cannot leave the live hash path replaced while annotation deletes are undone
+
 .. _document-create-example:
 
 Example Lifecycle

--- a/docs/source/for_developers/basics/user_stories.rst
+++ b/docs/source/for_developers/basics/user_stories.rst
@@ -1722,6 +1722,34 @@ Manage Configurations
 
 -----
 
+Replace Document File from Admin Tools
+--------------------------------------
+
+.. container:: user-story
+
+   :Story:
+     As an **Admin**, I want to replace the PDF or ZIP file of an existing document from
+     Admin Tools, so that I can correct a wrong submission file without creating a new
+     document or breaking existing links that use the same document id and hash.
+
+   :Acceptance:
+     - From Settings → Admin Tools, I can open the replace-document-file tool.
+     - I can filter and search documents, select one PDF or ZIP document, and upload a
+       replacement file of the same type.
+     - After a successful replace, the document keeps the same id and hash; only the file
+       bytes on disk change.
+     - When I replace a PDF, existing CARE annotations and comments on that document are
+       removed.
+
+     **Negative cases:**
+
+     - When I am not an admin, I cannot use Admin Tools or the replace socket.
+     - When the uploaded file extension does not match the selected document type, the
+       replace is rejected and the stored file is unchanged.
+     - When the selected document is not a PDF or ZIP, the tool does not allow replace.
+
+-----
+
 Export User Statistics
 -----------------------
 

--- a/frontend/src/components/dashboard/AdminTools.vue
+++ b/frontend/src/components/dashboard/AdminTools.vue
@@ -1,0 +1,70 @@
+<template>
+  <div>
+    <Card title="Admin Tools">
+      <template #body>
+        <p class="text-muted mb-3">
+          Administrative utilities for recovering and maintaining system files.
+          Open a tool below to run a specific admin action.
+        </p>
+
+        <div class="d-flex flex-column gap-2 align-items-start">
+          <BasicButton
+              class="btn btn-outline-secondary"
+              text="Replace document file"
+              title="Replace an existing PDF or ZIP file on disk"
+              icon="arrow-repeat"
+              @click="openReplaceDocumentFileModal"
+          />
+        </div>
+      </template>
+    </Card>
+
+    <ReplaceDocumentFileModal
+        v-if="modals.replaceDocumentFile"
+        ref="replaceDocumentFileModal"
+        @hide="modals.replaceDocumentFile = false"
+    />
+  </div>
+</template>
+
+<script>
+import Card from "@/basic/dashboard/card/Card.vue";
+import BasicButton from "@/basic/Button.vue";
+import ReplaceDocumentFileModal from "@/components/dashboard/admin_tools/ReplaceDocumentFileModal.vue";
+
+/**
+ * Admin Tools dashboard page.
+ *
+ * Extensible list of admin utilities; each tool opens its own modal.
+ * Tool modals mount only while open so their table subscriptions stay idle.
+ *
+ * @author Mohammad Elwan
+ */
+export default {
+  name: "AdminTools",
+  components: {
+    Card,
+    BasicButton,
+    ReplaceDocumentFileModal,
+  },
+  data() {
+    return {
+      modals: {
+        replaceDocumentFile: false,
+      },
+    };
+  },
+  methods: {
+    /**
+     * Mount and open the document file replace modal.
+     */
+    openReplaceDocumentFileModal() {
+      this.modals.replaceDocumentFile = true;
+      this.$nextTick(() => this.$refs.replaceDocumentFileModal?.open());
+    },
+  },
+};
+</script>
+
+<style scoped>
+</style>

--- a/frontend/src/components/dashboard/admin_tools/ReplaceDocumentFileModal.vue
+++ b/frontend/src/components/dashboard/admin_tools/ReplaceDocumentFileModal.vue
@@ -1,0 +1,331 @@
+<template>
+  <Modal
+      ref="replaceModal"
+      name="replaceDocumentFile"
+      size="xl"
+  >
+    <template #title>
+      Replace document file
+    </template>
+
+    <template #body>
+      <div class="modal-body">
+        <div
+            v-if="replacing"
+            class="d-flex justify-content-center m-5"
+        >
+          <div
+              class="spinner-border"
+              role="status"
+          >
+            <span class="visually-hidden">Replacing...</span>
+          </div>
+        </div>
+
+        <div v-else>
+          <p class="mb-3">
+            Upload a new PDF or ZIP to overwrite the file stored for an existing document.
+            The document keeps the same title, id, and links; only the file bytes change.
+            The uploaded file type must match the document type.
+            For PDFs, existing CARE annotations and comments on that document are removed.
+          </p>
+
+          <div class="mb-3">
+            <label
+                class="form-label"
+                for="replace-doc-type-filter"
+            >Type</label>
+            <select
+                id="replace-doc-type-filter"
+                v-model="typeFilter"
+                class="form-select"
+            >
+              <option value="all">All (PDF &amp; ZIP)</option>
+              <option value="pdf">PDF only</option>
+              <option value="zip">ZIP only</option>
+            </select>
+          </div>
+
+          <BasicTable
+              v-model="selectedRows"
+              :columns="columns"
+              :data="tableData"
+              :options="tableOptions"
+              :max-table-height="320"
+          />
+
+          <p
+              v-if="selectedDocument"
+              class="small text-muted mt-2 mb-3"
+          >
+            Selected:
+            <strong>{{ selectedDocument.name || "(unnamed)" }}</strong>
+            (#{{ selectedDocument.id }}, {{ selectedDocument.typeName }}).
+          </p>
+          <p
+              v-else
+              class="small text-muted mt-2 mb-3"
+          >
+            Select one document in the table (10 per page; use search or next page for more).
+          </p>
+
+          <BasicForm
+              v-model="formData"
+              :fields="fileFields"
+              @file-change="handleFileChange"
+          />
+        </div>
+      </div>
+    </template>
+
+    <template #footer>
+      <div
+          v-if="!replacing"
+          class="btn-group"
+      >
+        <BasicButton
+            class="btn btn-secondary"
+            text="Close"
+            title="Close"
+            @click="$refs.replaceModal.close()"
+        />
+        <BasicButton
+            class="btn btn-primary"
+            text="Replace file"
+            title="Replace file"
+            :disabled="!canSubmit"
+            @click="replace"
+        />
+      </div>
+    </template>
+  </Modal>
+</template>
+
+<script>
+import Modal from "@/basic/Modal.vue";
+import BasicButton from "@/basic/Button.vue";
+import BasicForm from "@/basic/Form.vue";
+import BasicTable from "@/basic/Table.vue";
+
+const DOC_TYPE_PDF = 0;
+const DOC_TYPE_ZIP = 4;
+
+const TYPE_EXTENSION = {
+  [DOC_TYPE_PDF]: ".pdf",
+  [DOC_TYPE_ZIP]: ".zip",
+};
+
+/**
+ * Modal to replace an existing document's PDF or ZIP file on disk.
+ *
+ * @author Mohammad Elwan
+ */
+export default {
+  name: "ReplaceDocumentFileModal",
+  subscribeTable: ["document"],
+  components: {
+    Modal,
+    BasicButton,
+    BasicForm,
+    BasicTable,
+  },
+  data() {
+    return {
+      replacing: false,
+      typeFilter: "all",
+      selectedRows: [],
+      selectedFile: null,
+      formData: {
+        file: null,
+      },
+      columns: [
+        {name: "ID", key: "id", sortable: true},
+        {name: "Title", key: "name", sortable: true, multiline: true},
+        {name: "Type", key: "typeName", sortable: true},
+      ],
+      tableOptions: {
+        striped: true,
+        hover: true,
+        bordered: false,
+        borderless: false,
+        small: true,
+        selectableRows: true,
+        singleSelect: true,
+        search: true,
+        pagination: 10,
+      },
+    };
+  },
+  computed: {
+    tableData() {
+      const all = this.$store.getters["table/document/getAll"] || [];
+      return all
+          .filter((doc) => {
+            if (!doc || doc.deleted) {
+              return false;
+            }
+            if (doc.type !== DOC_TYPE_PDF && doc.type !== DOC_TYPE_ZIP) {
+              return false;
+            }
+            if (this.typeFilter === "pdf" && doc.type !== DOC_TYPE_PDF) {
+              return false;
+            }
+            if (this.typeFilter === "zip" && doc.type !== DOC_TYPE_ZIP) {
+              return false;
+            }
+            return true;
+          })
+          .map((doc) => ({
+            ...doc,
+            name: doc.name || "(unnamed)",
+            typeName: this.typeLabel(doc.type),
+          }));
+    },
+    selectedDocument() {
+      if (!this.selectedRows || this.selectedRows.length === 0) {
+        return null;
+      }
+      const selected = this.selectedRows[0];
+      const id = Number(selected.id);
+      return this.tableData.find((doc) => Number(doc.id) === id) || selected;
+    },
+    fileFields() {
+      return [
+        {
+          key: "file",
+          type: "file",
+          label: "Replacement file",
+          accept: this.selectedDocument
+              ? TYPE_EXTENSION[this.selectedDocument.type]
+              : this.acceptForFilter,
+          class: "form-control",
+          default: null,
+        },
+      ];
+    },
+    acceptForFilter() {
+      if (this.typeFilter === "pdf") {
+        return ".pdf";
+      }
+      if (this.typeFilter === "zip") {
+        return ".zip";
+      }
+      return ".pdf,.zip";
+    },
+    canSubmit() {
+      return Boolean(this.selectedDocument && this.selectedFile);
+    },
+  },
+  watch: {
+    typeFilter() {
+      this.clearSelectionIfFilteredOut();
+    },
+    tableData() {
+      this.clearSelectionIfFilteredOut();
+    },
+  },
+  methods: {
+    /**
+     * Human-readable label for a document type.
+     * @param {number} type - Document type enum value
+     * @returns {string}
+     */
+    typeLabel(type) {
+      if (type === DOC_TYPE_PDF) {
+        return "PDF";
+      }
+      if (type === DOC_TYPE_ZIP) {
+        return "ZIP";
+      }
+      return "Unknown";
+    },
+
+    /**
+     * Clear selection when the selected document is no longer in the filtered table.
+     */
+    clearSelectionIfFilteredOut() {
+      if (!this.selectedRows || this.selectedRows.length === 0) {
+        return;
+      }
+      const id = Number(this.selectedRows[0].id);
+      const stillVisible = this.tableData.some((doc) => Number(doc.id) === id);
+      if (!stillVisible) {
+        this.selectedRows = [];
+      }
+    },
+
+    handleFileChange(file) {
+      this.selectedFile = file || null;
+    },
+
+    /**
+     * Open the modal and reset form state.
+     */
+    open() {
+      this.replacing = false;
+      this.typeFilter = "all";
+      this.selectedRows = [];
+      this.selectedFile = null;
+      this.formData = {
+        file: null,
+      };
+      this.$refs.replaceModal.open();
+    },
+
+    /**
+     * Validate client-side type match and emit documentReplaceFile.
+     */
+    replace() {
+      if (!this.canSubmit) {
+        return;
+      }
+
+      const expectedExtension = TYPE_EXTENSION[this.selectedDocument.type];
+      const fileName = this.selectedFile.name || "";
+      const fileExtension = fileName.substring(fileName.lastIndexOf(".")).toLowerCase();
+
+      if (fileExtension !== expectedExtension) {
+        this.eventBus.emit("toast", {
+          title: "Type mismatch",
+          message: `Document is ${this.typeLabel(this.selectedDocument.type)}; please upload a ${expectedExtension} file.`,
+          variant: "danger",
+        });
+        return;
+      }
+
+      this.replacing = true;
+      this.$refs.replaceModal.waiting = true;
+
+      const documentId = Number(this.selectedDocument.id);
+      const documentName = this.selectedDocument.name || "(unnamed)";
+
+      this.$socket.emit("documentReplaceFile", {
+        documentId,
+        file: this.selectedFile,
+        name: fileName,
+      }, (res) => {
+        this.replacing = false;
+        this.$refs.replaceModal.waiting = false;
+
+        if (res.success) {
+          this.eventBus.emit("toast", {
+            title: "File replaced",
+            message: `Updated file for “${documentName}” (#${documentId}).`,
+            variant: "success",
+          });
+          this.$refs.replaceModal.close();
+        } else {
+          this.eventBus.emit("toast", {
+            title: "Replace failed",
+            message: res.message || "Could not replace document file.",
+            variant: "danger",
+          });
+        }
+      });
+    },
+  },
+};
+</script>
+
+<style scoped>
+</style>

--- a/frontend/src/components/dashboard/admin_tools/ReplaceDocumentFileModal.vue
+++ b/frontend/src/components/dashboard/admin_tools/ReplaceDocumentFileModal.vue
@@ -242,6 +242,7 @@ export default {
 
     /**
      * Clear selection when the selected document is no longer in the filtered table.
+     * @returns {void}
      */
     clearSelectionIfFilteredOut() {
       if (!this.selectedRows || this.selectedRows.length === 0) {
@@ -254,12 +255,18 @@ export default {
       }
     },
 
+    /**
+     * Store the selected replacement file from the form upload control.
+     * @param {File} file - The file chosen by the user, or null when cleared
+     * @returns {void}
+     */
     handleFileChange(file) {
       this.selectedFile = file || null;
     },
 
     /**
      * Open the modal and reset form state.
+     * @returns {void}
      */
     open() {
       this.replacing = false;
@@ -274,6 +281,7 @@ export default {
 
     /**
      * Validate client-side type match and emit documentReplaceFile.
+     * @returns {void}
      */
     replace() {
       if (!this.canSubmit) {


### PR DESCRIPTION
## Summary
Adds an admin-only Admin Tools dashboard page (Settings nav) with a first tool to replace an existing document’s PDF or ZIP file on disk while keeping the same document id/hash. Intended for correcting a wrong submission file after the submission is closed.

## New User Features
- Admin Tools page under Settings (`admin_tools`), admin-only nav entry
- Replace document file modal: type filter, search, paginated selectable table (10/page), upload replacement file
- Tool modal mounts only while open (lazy `v-if`) so document subscription is not loaded until needed

## New Dev Features
- `nav_element` migration for Admin Tools (`component: AdminTools`, path `admin_tools`)
- Socket `documentReplaceFile` (admin-gated, transactional): validates PDF/ZIP type match, for PDFs clears CARE annotations/comments and best-effort strips embedded PDF annotations via PDFRPC, then overwrites `files/{hash}.{pdf|zip}`

## Known Limitations
- If PDFRPC strip fails, the raw uploaded PDF is written instead
- No “import annotations from replacement PDF” option

## Future Steps / open questions for review
- **Clearing old CARE annotations:** Keep always wiping CARE annotations/comments on PDF replace, or make it optional?
- Optional later: import-annotations checkbox on replace similar to upload Document
- Optional later: server-side document paging for very large admin document lists
