### PR TITLE
fix: add tooltip on hover for help icon in settings

### DIFF
--- a/frontend/src/basic/form/Help.vue
+++ b/frontend/src/basic/form/Help.vue
@@ -1,6 +1,7 @@
 <template>
   <span
     v-if="help"
+    ref="tooltip"
     v-tooltip="!!help"
     class="btn btn-sm mt-0 pt-0 border-0"
     :class="buttonClass"

--- a/frontend/src/basic/form/Help.vue
+++ b/frontend/src/basic/form/Help.vue
@@ -18,6 +18,7 @@
 
 <script>
 import LoadIcon from "@/basic/Icon.vue";
+import { Tooltip } from "bootstrap";
 
 /**
  * Show help icon with tooltip if help is provided.
@@ -42,11 +43,22 @@ export default {
       default: null,
     },
   },
-  mounted() {
-    //new Tooltip(this.$refs.tooltip, {trigger: "click"});
-  }
-}
+
+   mounted() {
+    if (!this.$refs.tooltip) return;
+
+    this.tooltipInstance = new Tooltip(this.$refs.tooltip, {
+      trigger: "hover focus",
+      delay: 0,
+    });
+  },
+
+  beforeUnmount() {
+    this.tooltipInstance?.dispose();
+  },
+};
 </script>
+
 
 <style scoped>
 

--- a/frontend/src/basic/form/Help.vue
+++ b/frontend/src/basic/form/Help.vue
@@ -1,7 +1,7 @@
 <template>
   <span
     v-if="help"
-    ref="tooltip"
+    v-tooltip="!!help"
     class="btn btn-sm mt-0 pt-0 border-0"
     :class="buttonClass"
     :title="help"
@@ -18,16 +18,21 @@
 
 <script>
 import LoadIcon from "@/basic/Icon.vue";
-import { Tooltip } from "bootstrap";
+import { tooltip } from "@/assets/tooltip.js";
 
 /**
  * Show help icon with tooltip if help is provided.
  */
-export default {
+ export default {
   name: "FormHelp",
   components: {
     LoadIcon
   },
+
+  directives: {
+    tooltip,
+  },
+
   props: {
     help: {
       type: String,
@@ -42,19 +47,6 @@ export default {
       type: [String, Object, Array],
       default: null,
     },
-  },
-
-   mounted() {
-    if (!this.$refs.tooltip) return;
-
-    this.tooltipInstance = new Tooltip(this.$refs.tooltip, {
-      trigger: "hover focus",
-      delay: 0,
-    });
-  },
-
-  beforeUnmount() {
-    this.tooltipInstance?.dispose();
   },
 };
 </script>


### PR DESCRIPTION
This pull request adds a tooltip which appears when you hover over a help icon in settings dashboard.
It resolves the issue: https://github.com/UKPLab/CARE/issues/171