### PR TITLE
[FIX] Always open the weekly minor/patch dependency PR

### DIFF
--- a/.github/workflows/weekly-dependency-updates.yml
+++ b/.github/workflows/weekly-dependency-updates.yml
@@ -20,7 +20,8 @@ env:
     utils/modules/assessment-score
 
 jobs:
-  # Minor + patch only. Updates must pass npm audit before the PR is opened.
+  # Minor + patch only. Always open a PR when those bumps exist.
+  # Remaining audit issues (majors / npm audit fix --force) do not block the PR.
   update-minor-patch:
     if: github.event_name == 'workflow_dispatch' || github.event.schedule == '0 6 * * 1'
     runs-on: ubuntu-latest
@@ -45,10 +46,13 @@ jobs:
               cd "${dir}"
               npx --yes npm-check-updates -u --target minor
               npm install --no-fund --no-audit
+              # Non-breaking security patches only. Remaining vulns must not abort the job.
+              npm audit fix || true
             )
           done <<< "${PACKAGE_DIRS}"
 
       - name: Run npm audit
+        continue-on-error: true
         run: make audit
 
       - name: Create minor/patch Pull Request
@@ -67,8 +71,9 @@ jobs:
             - `utils/modules/editor-delta-conversion`
             - `utils/modules/assessment-score`
 
-            `make audit` passed on this branch before the PR was opened.
-            Please still review the diff and let CI finish before merging.
+            Includes non-breaking `npm audit fix` patches. Remaining audit
+            findings (those that need a major bump) do not block this PR.
+            Please review the diff and let CI / `make audit` finish before merging.
           labels: dependencies
 
   # Major only (quarterly). Reminder PR with bumps applied for testing —


### PR DESCRIPTION
The weekly update job now still opens a PR when small package updates exist, even if the security check still reports leftover issues.

### New User Features
- None

### New Dev Features
- Weekly minor/patch updates now always open a PR for review
- Safe security patches are included in that same PR

### Improvements
- The security check still runs and is shown in the job log, but it no longer stops the PR from being created

### Bug Fixes
- Fixes the weekly job skipping the PR when the security check fails after small updates

### Known Limitations
- Issues that need a major package upgrade are still not applied automatically
- Reviewers should still check the PR diff, CI, and the security report before merging

### Future Steps
- After this is merged, run the dependency-updates workflow once so this week’s missed PR can be opened