### PR TITLE
Fix 364 show icon instead of text on annotator toolbar

### DIFF
--- a/frontend/src/components/annotator/pdfViewer/PDFToolbar.vue
+++ b/frontend/src/components/annotator/pdfViewer/PDFToolbar.vue
@@ -36,7 +36,7 @@
     <BasicButton
       class="toolbar-toggle-btn"
       :icon="toolbarVisible ? 'chevron-right' : 'tools'"
-      :title="toolbarVisible ? $t('components.pdftoolbar.minToolbar') : $t('components.pdftoolbar.showToolbar')"
+      :tooltip="toolbarVisible ? $t('components.pdftoolbar.minToolbar') : $t('components.pdftoolbar.showToolbar')"
       @click="toggleToolbar"
     />
   </div>


### PR DESCRIPTION
## Summary
The annotator PDF toolbar toggle was rendering "Show Toolbar" / "Minimize Toolbar" as the button label. It now shows the icon only, with that string as the hover tooltip.

## Bug Fixes
- PDF toolbar toggle in `PDFToolbar.vue` passed `title` into `BasicButton`, which uses `title` as visible text. Switched to `tooltip` so the tools / chevron icon is the only visible control.